### PR TITLE
Fixed GitHub Build Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ usb_*.spec
 
 CMakeUserPresets.json
 build_patreon.sh
+.vs/

--- a/sphaira/CMakeLists.txt
+++ b/sphaira/CMakeLists.txt
@@ -307,6 +307,7 @@ if (ENABLE_LIBUSBDVD)
     FetchContent_Declare(libusbdvd
         GIT_REPOSITORY https://github.com/proconsule/libusbdvd.git
         GIT_TAG 3cb0613
+        PATCH_COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/patches/patch_libusbdvd.py"
     )
 
     FetchContent_MakeAvailable(libusbdvd)

--- a/sphaira/patches/patch_libusbdvd.py
+++ b/sphaira/patches/patch_libusbdvd.py
@@ -1,0 +1,36 @@
+"""
+Removes enum usb_request_type and enum usb_request_recipient from
+libusbdvd's switch_usb.cpp.  These are now provided by the libnx header
+switch/services/usb.h (included transitively via <switch.h>), so keeping
+the local definitions causes "redefinition of enum" errors with newer
+devkitpro toolchains.
+
+This script is run by CMake's PATCH_COMMAND immediately after libusbdvd is
+cloned.  The working directory is the root of the cloned repository.
+"""
+
+import re
+
+FILEPATH = "source/os/switch/switch_usb.cpp"
+
+with open(FILEPATH, "r") as f:
+    content = f.read()
+
+# Remove conflicting enum definitions (no-op if already absent).
+content = re.sub(
+    r"\nenum usb_request_type\s*\{[^}]*\};\s*",
+    "\n",
+    content,
+    flags=re.DOTALL,
+)
+content = re.sub(
+    r"\nenum usb_request_recipient\s*\{[^}]*\};\s*",
+    "\n",
+    content,
+    flags=re.DOTALL,
+)
+
+with open(FILEPATH, "w") as f:
+    f.write(content)
+
+print("patch_libusbdvd.py: patched", FILEPATH)

--- a/sphaira/source/ui/menus/gc_menu.cpp
+++ b/sphaira/source/ui/menus/gc_menu.cpp
@@ -96,17 +96,6 @@ auto GetXciSizeFromRomSize(u8 rom_size) -> s64 {
     return 0;
 }
 
-struct DebugEventInfo {
-    u32 event_type;
-    u32 flags;
-    u64 thread_id;
-    u64 title_id;
-    u64 process_id;
-    char process_name[12];
-    u32 mmu_flags;
-    u8 _0x30[0x10];
-};
-
 auto GetDumpTypeStr(u8 type) -> const char* {
     switch (type) {
         case DumpFileType_TrimmedXCI:


### PR DESCRIPTION
v1.0.0 would not compile without this fix but not sure this is the most appropriate fix

**Here is the problem I had when compiling using GitHub Build Action :**

The build is failing due to multiple definition errors for enums that are already defined in the **libnx** header files. The issue is in switch_usb.cpp which redefines enum usb_request_recipient and enum usb_request_type that already exist in /opt/devkitpro/libnx/include/switch/services/usb.h.

**Root Cause**
The switch_usb.cpp file is defining USB enums locally instead of using the ones provided by the libnx library headers. This causes duplicate definition errors during compilation.

**Solution**
Remove the enum definitions from switch_usb.cpp and rely on the libnx headers instead.