### PR TITLE
[Feature] Add toggle to disable playtime statistics

### DIFF
--- a/assets/romfs/i18n/de.json
+++ b/assets/romfs/i18n/de.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Spielstatistiken aktualisieren",
   "Failed to update play statistics!": "Spielstatistik konnte nicht aktualisiert werden!",
   "Play statistics unavailable": "Spielstatistiken nicht verfügbar",
+  "Play statistics": "Spielstatistiken",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Zeigt die Spielzeit an und aktiviert die Sortierung nach Spielstatistiken. Deaktivieren für schnellere Listenaktualisierungen und weniger Schreibvorgänge auf der SD-Karte bei großen Bibliotheken.",
   "No statistics": "Keine Statistik",
   "Empty!": "Keine Daten!",
   "Filter: %s | Sort: %s | Order: %s": "Rubrik: %s | Sort.nach.: %s | Ordnung: %s",

--- a/assets/romfs/i18n/en.json
+++ b/assets/romfs/i18n/en.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Updating play statistics",
   "Failed to update play statistics!": "Failed to update play statistics!",
   "Play statistics unavailable": "Play statistics unavailable",
+  "Play statistics": "Play statistics",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.",
   "No statistics": "No statistics",
   "Empty!": "Empty!",
   "Filter: %s | Sort: %s | Order: %s": "Filter: %s | Sort: %s | Order: %s",

--- a/assets/romfs/i18n/es.json
+++ b/assets/romfs/i18n/es.json
@@ -512,6 +512,8 @@
   "Updating play statistics": "Actualizando estadísticas de juego",
   "Failed to update play statistics!": "¡No se pudieron actualizar las estadísticas de juego!",
   "Play statistics unavailable": "Estadísticas de reproducción no disponibles",
+  "Play statistics": "Estadísticas de juego",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Muestra el tiempo de juego y habilita los ordenamientos por estadísticas de juego. Desactívalo para actualizar la lista más rápido y reducir las escrituras en la tarjeta SD en bibliotecas grandes.",
   "No statistics": "Sin estadísticas",
   "Empty!": "¡Vacío!",
   "Filter: %s | Sort: %s | Order: %s": "Filtro: %s | Ordenar: %s | Orden: %s",

--- a/assets/romfs/i18n/fr.json
+++ b/assets/romfs/i18n/fr.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Mise à jour des statistiques de jeu",
   "Failed to update play statistics!": "Échec de la mise à jour des statistiques de jeu !",
   "Play statistics unavailable": "Statistiques de jeu indisponibles",
+  "Play statistics": "Statistiques de jeu",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Affiche le temps de jeu et active les tris par statistiques de jeu. Désactivez pour accélérer l'actualisation de la liste et réduire les écritures sur la carte SD sur les grandes bibliothèques.",
   "No statistics": "Aucune statistique",
   "Empty!": "Vide !",
   "Filter: %s | Sort: %s | Order: %s": "Filtre : %s | Trier : %s | Commande : %s",

--- a/assets/romfs/i18n/it.json
+++ b/assets/romfs/i18n/it.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Aggiornamento delle statistiche di gioco",
   "Failed to update play statistics!": "Impossibile aggiornare le statistiche di gioco!",
   "Play statistics unavailable": "Statistiche di gioco non disponibili",
+  "Play statistics": "Statistiche di gioco",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Mostra il tempo di gioco e abilita gli ordinamenti per statistiche di gioco. Disattiva per aggiornamenti della lista più rapidi e meno scritture sulla scheda SD con librerie di grandi dimensioni.",
   "No statistics": "Nessuna statistica",
   "Empty!": "Vuoto!",
   "Filter: %s | Sort: %s | Order: %s": "Filtro: %s | Riordina: %s | Ordina: %s",

--- a/assets/romfs/i18n/ja.json
+++ b/assets/romfs/i18n/ja.json
@@ -503,6 +503,8 @@
   "Updating play statistics": "プレイ統計の更新",
   "Failed to update play statistics!": "プレイ統計を更新できませんでした。",
   "Play statistics unavailable": "プレイ統計は利用できません",
+  "Play statistics": "プレイ統計",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "プレイ時間を表示し、プレイ統計による並べ替えを有効にします。無効にすると、大きなライブラリでのリスト更新が速くなり、SDカードへの書き込みが減ります。",
   "No statistics": "統計はありません",
   "Empty!": "何も見つかりません",
   "Filter: %s | Sort: %s | Order: %s": "フィルター: %s | 並べ替え: %s | 順番: %s",

--- a/assets/romfs/i18n/ko.json
+++ b/assets/romfs/i18n/ko.json
@@ -507,6 +507,8 @@
   "Updating play statistics": "플레이 통계 업데이트 중",
   "Failed to update play statistics!": "플레이 통계 업데이트에 실패했습니다!",
   "Play statistics unavailable": "플레이 통계를 사용할 수 없습니다.",
+  "Play statistics": "플레이 통계",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "플레이 시간을 표시하고 플레이 통계 정렬을 사용합니다. 큰 라이브러리에서 목록 새로 고침 속도를 높이고 SD 카드 쓰기를 줄이려면 비활성화하세요.",
   "No statistics": "통계 없음",
   "Empty!": "찾을 수 없습니다!",
   "Filter: %s | Sort: %s | Order: %s": "필터: %s | 분류: %s | 정렬: %s",

--- a/assets/romfs/i18n/nl.json
+++ b/assets/romfs/i18n/nl.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Speelstatistieken bijwerken",
   "Failed to update play statistics!": "Kan de spelstatistieken niet bijwerken!",
   "Play statistics unavailable": "Speelstatistieken niet beschikbaar",
+  "Play statistics": "Speelstatistieken",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Toont de speeltijd en schakelt het sorteren op speelstatistieken in. Schakel uit voor snellere lijstvernieuwingen en minder schrijfacties naar de SD-kaart bij grote bibliotheken.",
   "No statistics": "Geen statistieken",
   "Empty!": "Leeg!",
   "Filter: %s | Sort: %s | Order: %s": "Filter: %s | Soort: %s | Volgorde: %s",

--- a/assets/romfs/i18n/pt.json
+++ b/assets/romfs/i18n/pt.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Atualizando estatísticas de jogo",
   "Failed to update play statistics!": "Falha ao atualizar as estatísticas de jogo!",
   "Play statistics unavailable": "Estatísticas de jogo indisponíveis",
+  "Play statistics": "Estatísticas de jogo",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Mostra o tempo de jogo e ativa as ordenações por estatísticas de jogo. Desative para atualizações da lista mais rápidas e menos escritas no cartão SD em bibliotecas grandes.",
   "No statistics": "Sem estatísticas",
   "Empty!": "Vazio.",
   "Filter: %s | Sort: %s | Order: %s": "Filtro: %s | Cla.: %s | Ordem: %s",

--- a/assets/romfs/i18n/ru.json
+++ b/assets/romfs/i18n/ru.json
@@ -512,6 +512,8 @@
   "Updating play statistics": "Обновление игровой статистики",
   "Failed to update play statistics!": "Не удалось обновить игровую статистику!",
   "Play statistics unavailable": "Статистика игры недоступна.",
+  "Play statistics": "Игровая статистика",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Показывает время игры и включает сортировку по игровой статистике. Отключите для более быстрого обновления списка и меньшего числа записей на SD-карту в больших библиотеках.",
   "No statistics": "Нет статистики",
   "Empty!": "Пусто!",
   "Filter: %s | Sort: %s | Order: %s": "Показывать: %s | Сортировка: %s | Порядок: %s",

--- a/assets/romfs/i18n/se.json
+++ b/assets/romfs/i18n/se.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Uppdatering av spelstatistik",
   "Failed to update play statistics!": "Det gick inte att uppdatera spelstatistiken!",
   "Play statistics unavailable": "Spelstatistik är inte tillgänglig",
+  "Play statistics": "Spelstatistik",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Visar speltid och aktiverar sorteringar efter spelstatistik. Inaktivera för snabbare listuppdateringar och färre skrivningar till SD-kortet i stora bibliotek.",
   "No statistics": "Ingen statistik",
   "Empty!": "Tomt!",
   "Filter: %s | Sort: %s | Order: %s": "Filter: %s | Sortering: %s | Ordning: %s",

--- a/assets/romfs/i18n/uk.json
+++ b/assets/romfs/i18n/uk.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Оновлення статистики гри",
   "Failed to update play statistics!": "Не вдалося оновити статистику гри!",
   "Play statistics unavailable": "Статистика гри недоступна",
+  "Play statistics": "Статистика гри",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Показує час гри та вмикає сортування за статистикою гри. Вимкніть для швидшого оновлення списку та меншої кількості записів на SD-картку у великих бібліотеках.",
   "No statistics": "Жодної статистики",
   "Empty!": "Пусто!",
   "Filter: %s | Sort: %s | Order: %s": "Фільтр: %s | Сорт.: %s | Порядок: %s",

--- a/assets/romfs/i18n/vi.json
+++ b/assets/romfs/i18n/vi.json
@@ -511,6 +511,8 @@
   "Updating play statistics": "Cập nhật số liệu thống kê lượt chơi",
   "Failed to update play statistics!": "Không thể cập nhật số liệu thống kê lượt chơi!",
   "Play statistics unavailable": "Thống kê trận đấu không có sẵn",
+  "Play statistics": "Thống kê lượt chơi",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "Hiển thị thời gian chơi và bật các kiểu sắp xếp theo thống kê lượt chơi. Tắt để làm mới danh sách nhanh hơn và giảm ghi vào thẻ SD với thư viện lớn.",
   "No statistics": "Không có số liệu thống kê",
   "Empty!": "Trống!",
   "Filter: %s | Sort: %s | Order: %s": "Lọc: %s | Sắp xếp: %s | Thứ tự: %s",

--- a/assets/romfs/i18n/zh-CN.json
+++ b/assets/romfs/i18n/zh-CN.json
@@ -495,6 +495,8 @@
   "Updating play statistics": "更新播放统计数据",
   "Failed to update play statistics!": "无法更新播放统计数据！",
   "Play statistics unavailable": "播放统计数据不可用",
+  "Play statistics": "播放统计数据",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "显示游戏时长并启用按播放统计数据排序。在大型库中禁用可加快列表刷新速度并减少 SD 卡写入。",
   "No statistics": "无统计数据",
   "Empty!": "空空如也！",
   "Filter: %s | Sort: %s | Order: %s": "筛选: %s | 排序: %s | 顺序: %s",

--- a/assets/romfs/i18n/zh-TW.json
+++ b/assets/romfs/i18n/zh-TW.json
@@ -497,6 +497,8 @@
   "Updating play statistics": "更新播放統計數據",
   "Failed to update play statistics!": "無法更新播放統計資料！",
   "Play statistics unavailable": "播放統計數據不可用",
+  "Play statistics": "播放統計數據",
+  "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries.": "顯示遊戲時長並啟用按播放統計數據排序。在大型庫中停用可加快清單重新整理速度並減少 SD 卡寫入。",
   "No statistics": "無統計數據",
   "Empty!": "空的！",
   "Filter: %s | Sort: %s | Order: %s": "篩選：%s | 排序：%s | 順序：%s",

--- a/sphaira/include/ui/menus/game_menu.hpp
+++ b/sphaira/include/ui/menus/game_menu.hpp
@@ -81,6 +81,11 @@ private:
     void StopPlaytimeWorker(bool apply_results);
     void ApplyPlaytimeResults();
     void SyncEntryToMaster(const Entry& entry);
+    void SetPlayStatsEnabled(bool enable);
+
+    auto IsPlayStatsEnabled() -> bool {
+        return m_play_stats.Get();
+    }
 
     auto GetSelectedEntries() const {
         std::vector<Entry> out;
@@ -134,6 +139,9 @@ private:
     option::OptionLong m_order{INI_SECTION, "order", OrderType::OrderType_Descending};
     option::OptionLong m_layout{INI_SECTION, "layout", LayoutType::LayoutType_Grid};
     option::OptionBool m_hide_forwarders{INI_SECTION, "hide_forwarders", false};
+    // when disabled, pdm:qry is never opened and playlog.ini is never touched
+    // by this menu, as both add per-entry io whilst navigating the list.
+    option::OptionBool m_play_stats{INI_SECTION, "play_stats", true};
 };
 
 struct NcmMetaData {

--- a/sphaira/source/ui/menus/game_menu.cpp
+++ b/sphaira/source/ui/menus/game_menu.cpp
@@ -539,13 +539,28 @@ Menu::Menu(u32 flags) : grid::Menu{"Games"_i18n, flags} {
                     auto options = std::make_unique<Sidebar>("Sort Options"_i18n, Sidebar::Side::RIGHT);
                     ON_SCOPE_EXIT(App::Push(std::move(options)));
 
+                    // the play statistic sorts are hidden when play statistics
+                    // are disabled, as there is no data to sort by.
                     SidebarEntryArray::Items sort_items;
-                    sort_items.push_back("Updated"_i18n);
-                    sort_items.push_back("Title"_i18n);
-                    sort_items.push_back("Title ID"_i18n);
-                    sort_items.push_back("Last played"_i18n);
-                    sort_items.push_back("Total playtime"_i18n);
-                    sort_items.push_back("Publisher"_i18n);
+                    std::vector<s64> sort_map;
+                    const auto add_sort = [&](const std::string& name, SortType type) {
+                        sort_items.push_back(name);
+                        sort_map.push_back(type);
+                    };
+
+                    add_sort("Updated"_i18n, SortType_Updated);
+                    add_sort("Title"_i18n, SortType_Title);
+                    add_sort("Title ID"_i18n, SortType_TitleID);
+                    if (IsPlayStatsEnabled()) {
+                        add_sort("Last played"_i18n, SortType_LastPlayed);
+                        add_sort("Total playtime"_i18n, SortType_TotalPlayTime);
+                    }
+                    add_sort("Publisher"_i18n, SortType_Publisher);
+
+                    auto sort_index = std::distance(sort_map.begin(), std::ranges::find(sort_map, m_sort.Get()));
+                    if (sort_index >= (s64)sort_map.size()) {
+                        sort_index = 0;
+                    }
 
                     SidebarEntryArray::Items order_items;
                     order_items.push_back("Descending"_i18n);
@@ -556,14 +571,15 @@ Menu::Menu(u32 flags) : grid::Menu{"Games"_i18n, flags} {
                     layout_items.push_back("Icon"_i18n);
                     layout_items.push_back("Grid"_i18n);
 
-                    options->Add<SidebarEntryArray>("Sort"_i18n, sort_items, [this](s64& index_out){
-                        if (index_out == SortType_TotalPlayTime) {
+                    options->Add<SidebarEntryArray>("Sort"_i18n, sort_items, [this, sort_map](s64& index_out){
+                        const auto sort = sort_map[index_out];
+                        if (sort == SortType_TotalPlayTime) {
                             LoadPlaytime();
                         } else {
-                            m_sort.Set(index_out);
+                            m_sort.Set(sort);
                             SortAndFindLastFile(false);
                         }
-                    }, m_sort.Get());
+                    }, sort_index);
 
                     options->Add<SidebarEntryArray>("Order"_i18n, order_items, [this](s64& index_out){
                         m_order.Set(index_out);
@@ -638,6 +654,10 @@ Menu::Menu(u32 flags) : grid::Menu{"Games"_i18n, flags} {
                     App::PopToMenu();
                 });
 
+                options->Add<SidebarEntryBool>("Play statistics"_i18n, m_play_stats.Get(), [this](bool& v_out){
+                    SetPlayStatsEnabled(v_out);
+                }, "Shows playtime and enables the play statistic sorts. Disable for faster list refreshes and fewer SD card writes on large libraries."_i18n);
+
                 options->Add<SidebarEntryCallback>("Create contents folder"_i18n, [this](){
                     const auto rc = fs::FsNativeSd().CreateDirectory(title::GetContentsPath(m_entries[m_index].app_id));
                     App::PushErrorBox(rc, "Folder create failed!"_i18n);
@@ -684,9 +704,11 @@ Menu::Menu(u32 flags) : grid::Menu{"Games"_i18n, flags} {
     ns::Initialize();
     es::Initialize();
     title::Init();
-    m_pdm_initialized = R_SUCCEEDED(pdmqryInitialize());
-    if (!m_pdm_initialized) {
-        log_write("[PDM] failed to initialize pdm:qry; play statistics will be unavailable\n");
+    if (m_play_stats.Get()) {
+        m_pdm_initialized = R_SUCCEEDED(pdmqryInitialize());
+        if (!m_pdm_initialized) {
+            log_write("[PDM] failed to initialize pdm:qry; play statistics will be unavailable\n");
+        }
     }
 
     fsOpenGameCardDetectionEventNotifier(std::addressof(m_gc_event_notifier));
@@ -804,6 +826,14 @@ void Menu::SetIndex(s64 index) {
     char title_id[33];
     std::snprintf(title_id, sizeof(title_id), "%016lX", entry.app_id);
 
+    // play statistics are disabled, the entries carry no playtime and no
+    // worker is running, so there is nothing to display or request.
+    if (!m_play_stats.Get()) {
+        SetTitleSubHeading(title_id);
+        this->SetSubHeading(std::to_string(m_index + 1) + " / " + std::to_string(m_entries.size()));
+        return;
+    }
+
     std::string title_info = title_id;
     if (!entry.user_playtimes.empty()) {
         bool showed_profile{};
@@ -844,6 +874,7 @@ void Menu::ScanHomebrew() {
 
     constexpr auto ENTRY_CHUNK_COUNT = 1000;
     const auto hide_forwarders = m_hide_forwarders.Get();
+    const auto play_stats = m_play_stats.Get();
     TimeStamp ts;
 
     App::SetBoostMode(true);
@@ -853,7 +884,7 @@ void Menu::ScanHomebrew() {
     m_entries.reserve(ENTRY_CHUNK_COUNT);
     g_change_signalled = false;
 
-    if (m_accounts.empty()) {
+    if (play_stats && m_accounts.empty()) {
         m_accounts = App::GetAccountList();
     }
 
@@ -884,6 +915,12 @@ void Menu::ScanHomebrew() {
             auto& entry = m_entries.emplace_back(e.application_id, e.last_event);
             batch_ids.push_back(entry.app_id);
 
+            // the cached playtime lookup is a full scan of playlog.ini per
+            // entry (and per user), skip it entirely when disabled.
+            if (!play_stats) {
+                continue;
+            }
+
             char section[33];
             std::snprintf(section, sizeof(section), "%016lX", entry.app_id);
             entry.playtime_cached_last_played = static_cast<u64>(ini_getl(section, "last_played", 0, App::PLAYLOG_PATH));
@@ -909,7 +946,7 @@ void Menu::ScanHomebrew() {
             }
         }
 
-        if (m_pdm_initialized && !batch_ids.empty()) {
+        if (play_stats && m_pdm_initialized && !batch_ids.empty()) {
             std::vector<PdmLastPlayTime> play_times(batch_ids.size());
             s32 play_time_count{};
             if (R_SUCCEEDED(pdmqryQueryLastPlayTime(true, play_times.data(), batch_ids.data(), batch_ids.size(), &play_time_count))) {
@@ -969,8 +1006,14 @@ void Menu::Filter() {
 }
 
 void Menu::Sort() {
-    const auto sort = m_sort.Get();
+    auto sort = m_sort.Get();
     const auto order = m_order.Get();
+
+    // guards against a stale sort being loaded from the config.
+    if (!m_play_stats.Get() && (sort == SortType_LastPlayed || sort == SortType_TotalPlayTime)) {
+        sort = SortType_Updated;
+        m_sort.Set(sort);
+    }
 
     switch (sort) {
         case SortType_Updated:
@@ -1051,7 +1094,7 @@ void Menu::SyncEntryToMaster(const Entry& entry) {
 }
 
 void Menu::StartPlaytimeWorker() {
-    if (!m_pdm_initialized || m_playtime_worker) {
+    if (!m_play_stats.Get() || !m_pdm_initialized || m_playtime_worker) {
         return;
     }
 
@@ -1111,8 +1154,44 @@ void Menu::ApplyPlaytimeResults() {
     }
 }
 
+void Menu::SetPlayStatsEnabled(bool enable) {
+    if (enable == m_play_stats.Get() && enable == m_pdm_initialized) {
+        return;
+    }
+
+    m_play_stats.Set(enable);
+
+    if (enable) {
+        if (!m_pdm_initialized) {
+            m_pdm_initialized = R_SUCCEEDED(pdmqryInitialize());
+            if (!m_pdm_initialized) {
+                log_write("[PDM] failed to initialize pdm:qry; play statistics will be unavailable\n");
+                App::Notify("Play statistics unavailable"_i18n);
+            }
+        }
+    } else {
+        // the worker must go before pdm:qry is closed, as it queries from
+        // its own thread.
+        StopPlaytimeWorker(false);
+
+        if (m_pdm_initialized) {
+            pdmqryExit();
+            m_pdm_initialized = false;
+        }
+
+        // fall back to a sort that does not need play statistics.
+        const auto sort = m_sort.Get();
+        if (sort == SortType_LastPlayed || sort == SortType_TotalPlayTime) {
+            m_sort.Set(SortType_Updated);
+        }
+    }
+
+    // rebuild the list so the stale playtime data is dropped / repopulated.
+    m_dirty = true;
+}
+
 void Menu::LoadPlaytime() {
-    if (!m_pdm_initialized) {
+    if (!m_play_stats.Get() || !m_pdm_initialized) {
         App::Notify("Play statistics unavailable"_i18n);
         return;
     }


### PR DESCRIPTION
Hi,

Thanks for the 1.0.4 release.

Commit ec854b0 fixed the latency of the game screen navigation introduced by the "_play statistics_" feature, but just delegated it to an async worker => `SetIndex()` no longer block `pdmqryQueryPlayStatisticsBy*` calls or `ini_getl/ini_putl` on every cursor move, that moved to `PlaytimeWorker()`.

The multiple I/O rewrite from issue #329 is still here, the async system only mitigate it.

The new "_killswitch's_" `SetIndex()` early-return only skips a Request() and some string building, and is kept mainly so entries don't all read "_No statistics_".

The toggle allows to disable the plays statistics display / scan / rewrite for ultrafast game list load & browsing. 

<img width="1280" height="720" alt="2026081409022600-DB1426D1DFD034027CECDE9C2DD914B8" src="https://github.com/user-attachments/assets/010e9e32-f190-4b38-b945-bef2e273a62c" />
