### PR TITLE
[Feature] Add screen toggle functionality during game install / dump process

### DIFF
--- a/assets/romfs/i18n/de.json
+++ b/assets/romfs/i18n/de.json
@@ -474,6 +474,7 @@
   "Downloading ": "Heruntergeladen wird: ",
   "Checking MD5": "Checke MD5 Prüfsumme",
   "Options": "Optionen",
+  "Screen Off": "Bildschirm aus",
   "More by Author": "Weitere Apps des Entwicklers",
   "Leave Feedback": "Feedback hinterlassen",
   "Visit Website": "Besuchen Sie die Website",

--- a/assets/romfs/i18n/en.json
+++ b/assets/romfs/i18n/en.json
@@ -474,6 +474,7 @@
   "Downloading ": "Downloading ",
   "Checking MD5": "Checking MD5",
   "Options": "Options",
+  "Screen Off": "Screen Off",
   "More by Author": "More by Author",
   "Leave Feedback": "Leave Feedback",
   "Visit Website": "Visit Website",

--- a/assets/romfs/i18n/es.json
+++ b/assets/romfs/i18n/es.json
@@ -475,6 +475,7 @@
   "Downloading ": "Descargando ",
   "Checking MD5": "Verificando MD5",
   "Options": "Opciones",
+  "Screen Off": "Apagar pantalla",
   "More by Author": "Más del autor",
   "Leave Feedback": "Dejar opinión",
   "Visit Website": "Visitar sitio web",

--- a/assets/romfs/i18n/fr.json
+++ b/assets/romfs/i18n/fr.json
@@ -474,6 +474,7 @@
   "Downloading ": "Téléchargement en cours...",
   "Checking MD5": "Vérification MD5",
   "Options": "Possibilités",
+  "Screen Off": "Éteindre l'écran",
   "More by Author": "Plus de cet auteur",
   "Leave Feedback": "Laisser un avis",
   "Visit Website": "Visitez le site Web",

--- a/assets/romfs/i18n/it.json
+++ b/assets/romfs/i18n/it.json
@@ -474,6 +474,7 @@
   "Downloading ": "Scaricando",
   "Checking MD5": "Controllo MD5",
   "Options": "Opzioni",
+  "Screen Off": "Spegni schermo",
   "More by Author": "Altro per autore",
   "Leave Feedback": "Lascia un feedback",
   "Visit Website": "Visita il sito web",

--- a/assets/romfs/i18n/ja.json
+++ b/assets/romfs/i18n/ja.json
@@ -466,6 +466,7 @@
   "Downloading ": "ダウンロード中 ",
   "Checking MD5": "MD5を確認中 ",
   "Options": "設定",
+  "Screen Off": "画面オフ",
   "More by Author": "開発者の他のアプリを見る",
   "Leave Feedback": "意見を残す",
   "Visit Website": "ウェブサイトを開く",

--- a/assets/romfs/i18n/ko.json
+++ b/assets/romfs/i18n/ko.json
@@ -470,6 +470,7 @@
   "Downloading ": " 다운로드 중",
   "Checking MD5": "MD5 확인 중",
   "Options": "설정",
+  "Screen Off": "화면 끄기",
   "More by Author": "개발자의 다른 앱 더 보기",
   "Leave Feedback": "피드백 남기기",
   "Visit Website": "웹사이트 방문",

--- a/assets/romfs/i18n/nl.json
+++ b/assets/romfs/i18n/nl.json
@@ -474,6 +474,7 @@
   "Downloading ": "Downloaden ",
   "Checking MD5": "MD5 controleren",
   "Options": "Opties",
+  "Screen Off": "Scherm uit",
   "More by Author": "Meer per auteur",
   "Leave Feedback": "Laat feedback achter",
   "Visit Website": "Bezoek website",

--- a/assets/romfs/i18n/pt.json
+++ b/assets/romfs/i18n/pt.json
@@ -474,6 +474,7 @@
   "Downloading ": "Baixando ",
   "Checking MD5": "Checando MD5",
   "Options": "Opções",
+  "Screen Off": "Desligar tela",
   "More by Author": "Mais deste autor",
   "Leave Feedback": "Deixar um feedback",
   "Visit Website": "Visite o site",

--- a/assets/romfs/i18n/ru.json
+++ b/assets/romfs/i18n/ru.json
@@ -475,6 +475,7 @@
   "Downloading ": "Загрузка ",
   "Checking MD5": "Проверка MD5",
   "Options": "Опции",
+  "Screen Off": "Выключить экран",
   "More by Author": "Другое от автора",
   "Leave Feedback": "Оставить отзыв",
   "Visit Website": "Посетить сайт",

--- a/assets/romfs/i18n/se.json
+++ b/assets/romfs/i18n/se.json
@@ -474,6 +474,7 @@
   "Downloading ": "Laddar ner ",
   "Checking MD5": "Kontrollerar MD5",
   "Options": "Alternativ",
+  "Screen Off": "Skärm av",
   "More by Author": "Mer av författaren",
   "Leave Feedback": "Lämna feedback",
   "Visit Website": "Besök webbplatsen",

--- a/assets/romfs/i18n/uk.json
+++ b/assets/romfs/i18n/uk.json
@@ -474,6 +474,7 @@
   "Downloading ": "Завантаження ",
   "Checking MD5": "Перевірка MD5",
   "Options": "Налаштування",
+  "Screen Off": "Вимкнути екран",
   "More by Author": "Більше від автора",
   "Leave Feedback": "Залишити відгук",
   "Visit Website": "Відвідайте веб-сайт",

--- a/assets/romfs/i18n/vi.json
+++ b/assets/romfs/i18n/vi.json
@@ -474,6 +474,7 @@
   "Downloading ": "Đang tải xuống ",
   "Checking MD5": "Kiểm tra MD5",
   "Options": "Tuỳ chọn",
+  "Screen Off": "Tắt màn hình",
   "More by Author": "Xem thêm tác giả",
   "Leave Feedback": "Để lại phản hồi",
   "Visit Website": "Truy cập trang web",

--- a/assets/romfs/i18n/zh-CN.json
+++ b/assets/romfs/i18n/zh-CN.json
@@ -458,6 +458,7 @@
   "Downloading ": "正在下载 ",
   "Checking MD5": "正在校验 MD5",
   "Options": "选项",
+  "Screen Off": "关闭屏幕",
   "More by Author": "作者更多作品",
   "Leave Feedback": "留言反馈",
   "Visit Website": "访问网站",

--- a/assets/romfs/i18n/zh-TW.json
+++ b/assets/romfs/i18n/zh-TW.json
@@ -460,6 +460,7 @@
   "Downloading ": "正在下載 ",
   "Checking MD5": "正在檢查 MD5",
   "Options": "選項",
+  "Screen Off": "關閉螢幕",
   "More by Author": "作者的其他作品",
   "Leave Feedback": "留下回饋",
   "Visit Website": "造訪網站",

--- a/sphaira/include/app.hpp
+++ b/sphaira/include/app.hpp
@@ -212,6 +212,15 @@ public:
         }
     }
 
+    // enables the ability to turn the screen off, ref counted.
+    // the screen is always restored when the last reference is removed.
+    static void SetScreenToggleEnabled(bool enable);
+    static auto IsScreenToggleEnabled() -> bool;
+
+    // turns the lcd backlight off / on.
+    static void SetScreenDisabled(bool disable);
+    static auto IsScreenDisabled() -> bool;
+
     static void SetBoostMode(bool enable, bool force = false) {
         static Mutex mutex{};
         static int ref_count{};

--- a/sphaira/source/app.cpp
+++ b/sphaira/source/app.cpp
@@ -106,6 +106,10 @@ constexpr KeyboardState::MapEntry KEYBOARD_BUTTON_MAP[] = {
     {HidKeyboardKey_R,              static_cast<u64>(Button::SELECT)},
 };
 
+// used by the screen toggle (lcd backlight) api.
+Mutex g_screen_mutex{};
+int g_screen_toggle_ref{};
+
 constexpr NszOption NSZ_COMPRESS_LEVEL_OPTIONS[] = {
     { .value = 0, .name = "Level 0 (no compression)" },
     { .value = 1, .name = "Level 1" },
@@ -1042,6 +1046,56 @@ void App::ExitRestart() {
     Exit();
 }
 
+void App::SetScreenToggleEnabled(bool enable) {
+    SCOPED_MUTEX(&g_screen_mutex);
+
+    if (enable) {
+        if (!g_screen_toggle_ref) {
+            if (auto rc = lblInitialize(); R_FAILED(rc)) {
+                log_write("lblInitialize() failed: 0x%X\n", rc);
+                return;
+            }
+        }
+
+        g_screen_toggle_ref++;
+    } else {
+        if (!g_screen_toggle_ref) {
+            return;
+        }
+
+        g_screen_toggle_ref--;
+        if (!g_screen_toggle_ref) {
+            // always restore the screen for the next menu / on exit.
+            appletSetLcdBacklightOffEnabled(false);
+            lblExit();
+        }
+    }
+}
+
+auto App::IsScreenToggleEnabled() -> bool {
+    SCOPED_MUTEX(&g_screen_mutex);
+    return g_screen_toggle_ref > 0;
+}
+
+void App::SetScreenDisabled(bool disable) {
+    if (disable == IsScreenDisabled()) {
+        return;
+    }
+
+    // use applet here because it handles restoring the backlight
+    // when pressing the home / power button.
+    appletSetLcdBacklightOffEnabled(disable);
+}
+
+auto App::IsScreenDisabled() -> bool {
+    LblBacklightSwitchStatus status;
+    if (R_FAILED(lblGetBacklightSwitchStatus(&status))) {
+        return false;
+    }
+
+    return status != LblBacklightSwitchStatus_Enabled;
+}
+
 void App::Poll() {
     m_controller.Reset();
 
@@ -1160,6 +1214,14 @@ void App::Update() {
         if (song_state == audio::State::Finished) {
             audio::SeekSong(m_background_music, 0);
         }
+    }
+
+    // whilst the screen is disabled, the first button press restores it
+    // and is otherwise ignored, this way the screen is always restored
+    // before performing an action, such as cancelling an install or exiting.
+    if (m_controller.m_kdown && App::IsScreenToggleEnabled() && App::IsScreenDisabled()) {
+        App::SetScreenDisabled(false);
+        m_controller.Reset();
     }
 
     m_widgets.back()->Update(&m_controller, &m_touch_info);

--- a/sphaira/source/ui/menus/gc_menu.cpp
+++ b/sphaira/source/ui/menus/gc_menu.cpp
@@ -644,6 +644,15 @@ Menu::Menu(u32 flags) : MenuBase{"GameCard"_i18n, flags} {
         }})
     );
 
+    // allow turning the screen off during the install, any button press
+    // (or exiting this menu) restores it.
+    App::SetScreenToggleEnabled(true);
+    if (App::IsScreenToggleEnabled()) {
+        SetAction(Button::Y, Action{"Screen Off"_i18n, [](){
+            App::SetScreenDisabled(true);
+        }});
+    }
+
     const Vec4 v{485, 275, 720, 70};
     const Vec2 pad{0, 23.75};
 
@@ -661,6 +670,8 @@ Menu::~Menu() {
     eventClose(std::addressof(m_event));
     fsEventNotifierClose(std::addressof(m_event_notifier));
     fsDeviceOperatorClose(std::addressof(m_dev_op));
+
+    App::SetScreenToggleEnabled(false);
 }
 
 void Menu::Update(Controller* controller, TouchInfo* touch) {

--- a/sphaira/source/ui/menus/install_stream_menu_base.cpp
+++ b/sphaira/source/ui/menus/install_stream_menu_base.cpp
@@ -132,6 +132,15 @@ Menu::Menu(const std::string& title, u32 flags) : MenuBase{title, flags} {
         App::DisplayInstallOptions(false);
     }});
 
+    // allow turning the screen off during the install, any button press
+    // (or exiting this menu) restores it.
+    App::SetScreenToggleEnabled(true);
+    if (App::IsScreenToggleEnabled()) {
+        SetAction(Button::Y, Action{"Screen Off"_i18n, [](){
+            App::SetScreenDisabled(true);
+        }});
+    }
+
     App::SetAutoSleepDisabled(true);
     mutexInit(&m_mutex);
 
@@ -147,6 +156,7 @@ Menu::~Menu() {
     }
 
     App::SetAutoSleepDisabled(false);
+    App::SetScreenToggleEnabled(false);
 }
 
 void Menu::Update(Controller* controller, TouchInfo* touch) {

--- a/sphaira/source/ui/menus/usb_menu.cpp
+++ b/sphaira/source/ui/menus/usb_menu.cpp
@@ -33,6 +33,15 @@ Menu::Menu(u32 flags) : MenuBase{"USB"_i18n, flags} {
         App::DisplayInstallOptions(false);
     }});
 
+    // allow turning the screen off during the install, any button press
+    // (or exiting this menu) restores it.
+    App::SetScreenToggleEnabled(true);
+    if (App::IsScreenToggleEnabled()) {
+        SetAction(Button::Y, Action{"Screen Off"_i18n, [](){
+            App::SetScreenDisabled(true);
+        }});
+    }
+
     // if mtp is enabled, disable it for now.
     m_was_mtp_enabled = App::GetMtpEnable();
     if (m_was_mtp_enabled) {
@@ -71,6 +80,8 @@ Menu::~Menu() {
         App::Notify("Re-enabled MTP"_i18n);
         App::SetMtpEnable(true);
     }
+
+    App::SetScreenToggleEnabled(false);
 }
 
 void Menu::Update(Controller* controller, TouchInfo* touch) {

--- a/sphaira/source/ui/progress_box.cpp
+++ b/sphaira/source/ui/progress_box.cpp
@@ -43,6 +43,14 @@ ProgressBox::ProgressBox(int image, const std::string& action, const std::string
         });
     }});
 
+    // enabled by the install menus (mtp, usb, ftp), the screen is restored
+    // by the app on any button press and when leaving the install menu.
+    if (App::IsScreenToggleEnabled()) {
+        SetAction(Button::Y, Action{"Screen Off"_i18n, [](){
+            App::SetScreenDisabled(true);
+        }});
+    }
+
     m_pos.w = 770.f;
     m_pos.h = 295.f;
     m_pos.x = (SCREEN_WIDTH / 2.f) - (m_pos.w / 2.f);


### PR DESCRIPTION
Allow to shutdown the screen during extended install / dump processes to mitigate screen burn-in on OLED / LCD display.

Press Y button to shutdown the screen display, any button press re-enable it before registering an action.

As per request #332.

<img width="1280" height="720" alt="2026081410300600-DB1426D1DFD034027CECDE9C2DD914B8" src="https://github.com/user-attachments/assets/2972beff-e726-4dd3-8a63-3a12ef085018" />
