### PR TITLE
Fix forwarder editor touch input on options list

### DIFF
--- a/sphaira/source/ui/forwarder_editor.cpp
+++ b/sphaira/source/ui/forwarder_editor.cpp
@@ -126,11 +126,12 @@ public:
                 App::PlaySoundEffect(SoundEffect::Focus);
                 m_title_focused = false;
                 m_icon_focused = true;
+                return;
             } else if (controller->GotDown(Button::RIGHT)) {
                 App::PlaySoundEffect(SoundEffect::Focus);
                 m_title_focused = false;
+                return;
             }
-            return;
         }
 
         if (m_icon_focused) {
@@ -138,11 +139,12 @@ public:
                 App::PlaySoundEffect(SoundEffect::Focus);
                 m_icon_focused = false;
                 m_title_focused = true;
+                return;
             } else if (controller->GotDown(Button::RIGHT)) {
                 App::PlaySoundEffect(SoundEffect::Focus);
                 m_icon_focused = false;
+                return;
             }
-            return;
         }
 
         if (controller->GotDown(Button::LEFT)) {

--- a/sphaira/source/ui/forwarder_editor.cpp
+++ b/sphaira/source/ui/forwarder_editor.cpp
@@ -154,8 +154,15 @@ public:
             return;
         }
 
+        if ((m_title_focused || m_icon_focused)
+            && !touch->is_clicked && !touch->is_scroll && !touch->is_end) {
+            return;
+        }
+
         m_list->OnUpdate(controller, touch, m_index, m_rows.size(), [this](bool touched, s64 index){
             if (touched && m_index == index) {
+                m_icon_focused = false;
+                m_title_focused = false;
                 FireAction(Button::A);
             } else {
                 App::PlaySoundEffect(SoundEffect::Focus);


### PR DESCRIPTION
Fixes touch input in the forwarder editor so the right-column options list responds to taps.

The forwarder editor opens with the icon column focused by default. While the title or icon column was focused, `Update()` returned early before calling `m_list->OnUpdate()`, so taps on Profile Selection, Address Space, CPU Cores, and other right-column rows were ignored. Touch on the left column still worked because title and icon taps are handled before that early return.

This change only returns early when a controller button actually moves focus between the left column and the list. Touch events now reach the list, and the existing list callback clears left-column focus when a row is selected.

### Preview

https://github.com/user-attachments/assets/f71ffe4c-a782-498b-8e05-bdd3dad5b2e5


