### PR TITLE
Send a Sphaira/<version> User-Agent on all HTTP requests

### DIFF
--- a/sphaira/include/download.hpp
+++ b/sphaira/include/download.hpp
@@ -11,6 +11,9 @@
 
 namespace sphaira::curl {
 
+// identifies sphaira in curl requests
+constexpr auto USER_AGENT = "Sphaira/" APP_VERSION;
+
 enum {
     Flag_None = 0,
 

--- a/sphaira/source/download.cpp
+++ b/sphaira/source/download.cpp
@@ -30,7 +30,6 @@ namespace {
         log_write("curl_share_setopt(%s, %s) msg: %s\n", #opt, #v, curl_share_strerror(r)); \
     } \
 
-constexpr auto API_AGENT = "TotalJustice";
 constexpr u64 CHUNK_SIZE = 1024*1024;
 constexpr auto MAX_THREADS = 4;
 
@@ -612,7 +611,7 @@ auto EncodeUrl(const std::string& url) -> std::string {
 }
 
 void SetCommonCurlOptions(CURL* curl, const Api& e) {
-    CURL_EASY_SETOPT_LOG(curl, CURLOPT_USERAGENT, API_AGENT);
+    CURL_EASY_SETOPT_LOG(curl, CURLOPT_USERAGENT, USER_AGENT);
     CURL_EASY_SETOPT_LOG(curl, CURLOPT_FOLLOWLOCATION, 1L);
     CURL_EASY_SETOPT_LOG(curl, CURLOPT_SSL_VERIFYPEER, 0L);
     CURL_EASY_SETOPT_LOG(curl, CURLOPT_SSL_VERIFYHOST, 0L);

--- a/sphaira/source/utils/devoptab_common.cpp
+++ b/sphaira/source/utils/devoptab_common.cpp
@@ -1376,6 +1376,7 @@ void MountCurlDevice::curl_set_common_options(CURL* curl, const std::string& url
     // NOTE: port, user and pass are set in the curl_url.
     curl_easy_reset(curl);
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, sphaira::curl::USER_AGENT);
     curl_easy_setopt(curl, CURLOPT_AUTOREFERER, 1L);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 15L);


### PR DESCRIPTION
Sphaira uses curl requests across the app the fetch content from github, themes, and also access `HTTP` configured locations. It currently sets a `User-Agent: TotalJustice` header for all requests excepts for mounted network locations.

This PR sets the `User-Agent: Sphaira/<version>`  for all curl requests (except for `themezer` request where there is a specific `themezer-nx`), that allows client identification server side, also indicating supported features using the version string.

This will be very useful to fix a Sphaira client issue in Ownfoil: https://github.com/a1ex4/ownfoil/issues/325