### PR TITLE
fix: update NACP language handling and sanitization logic

### DIFF
--- a/sphaira/source/title_info.cpp
+++ b/sphaira/source/title_info.cpp
@@ -620,7 +620,17 @@ auto GetEnglishTitleName(u64 app_id) -> std::string {
     }
 
     NormalizeNacpLangData(nacp);
-    for (const auto language : {SetLanguage_ENUS, SetLanguage_ENGB}) {
+
+    // nacp entries are NOT indexed by SetLanguage, they use their own order
+    // (see g_nacpLanguageTable in libnx). SetLanguage_ENUS would read
+    // BritishEnglish and SetLanguage_ENGB would read Korean.
+    // slot 0 is also where NormalizeNacpLangData() stores the fallback name.
+    enum NacpLanguage {
+        NacpLanguage_AmericanEnglish = 0,
+        NacpLanguage_BritishEnglish = 1,
+    };
+
+    for (const auto language : {NacpLanguage_AmericanEnglish, NacpLanguage_BritishEnglish}) {
         const auto& entry = NacpLanguageEntries(nacp)[language];
         if (entry.name[0]) {
             return {std::begin(entry.name), std::find(std::begin(entry.name), std::end(entry.name), '\0')};
@@ -631,18 +641,35 @@ auto GetEnglishTitleName(u64 app_id) -> std::string {
 }
 
 auto MakeExportTitleName(std::string_view current_name, std::string_view english_name, bool fix_name) -> std::string {
-    std::string name{fix_name ? english_name : current_name};
-    if (name.empty()) {
-        return {};
+    const auto sanitise = [](std::string_view src, bool ascii_only) -> std::string {
+        std::string name{src};
+        if (name.empty()) {
+            return {};
+        }
+
+        utilsReplaceIllegalCharacters(name.data(), ascii_only);
+        name.resize(std::strlen(name.c_str()));
+
+        const auto usable = std::ranges::any_of(name, [](unsigned char c) {
+            return c != '_' && c != ' ' && c != '.';
+        });
+        return usable ? name : std::string{};
+    };
+
+    if (fix_name) {
+        // the english title is preferred as it's always ascii safe.
+        if (auto name = sanitise(english_name, true); !name.empty()) {
+            return name;
+        }
+
+        // the english title isn't always available (title has no english nacp
+        // entry, the control nca failed to parse, sys-tweak override, ...).
+        // fallback to the displayed name rather than losing the name entirely.
+        // if that has no ascii safe characters either, fall back to the title id.
+        return sanitise(current_name, true);
     }
 
-    utilsReplaceIllegalCharacters(name.data(), fix_name);
-    name.resize(std::strlen(name.c_str()));
-
-    const auto usable = std::ranges::any_of(name, [](unsigned char c) {
-        return c != '_' && c != ' ' && c != '.';
-    });
-    return usable ? name : std::string{};
+    return sanitise(current_name, false);
 }
 
 // taken from nxdumptool.

--- a/sphaira/source/utils/devoptab_game.cpp
+++ b/sphaira/source/utils/devoptab_game.cpp
@@ -43,6 +43,21 @@ struct Dir {
     u32 index;
 };
 
+// truncates to at most len bytes, without splitting a utf-8 sequence.
+auto TruncateUtf8(std::string str, size_t len) -> std::string {
+    if (str.size() <= len) {
+        return str;
+    }
+
+    // walk back over any continuation bytes so the name stays valid utf-8.
+    while (len && (static_cast<unsigned char>(str[len]) & 0xC0) == 0x80) {
+        len--;
+    }
+
+    str.resize(len);
+    return str;
+}
+
 void ParseId(std::string_view path, u64& id_out) {
     id_out = 0;
 
@@ -392,11 +407,16 @@ int Device::devoptab_dirnext(void* fd, char *filename, struct stat *filestat) {
                 const auto english_name = fix_filenames ? title::GetEnglishTitleName(entry.app_id) : std::string{};
                 entry.export_name = title::MakeExportTitleName(result->lang.name, english_name, fix_filenames);
 
-                const int name_max = sizeof(name) - 33;
-                if (entry.export_name.empty()) {
+                // the listed folder keeps the real (localised) title, only the exported
+                // nsp filenames follow the "fix export filenames" option.
+                const auto display_name = TruncateUtf8(
+                    title::MakeExportTitleName(result->lang.name, {}, false), sizeof(name) - 33
+                );
+
+                if (display_name.empty()) {
                     std::snprintf(name, sizeof(name), "[%016lX]", entry.app_id);
                 } else {
-                    std::snprintf(name, sizeof(name), "%.*s [%016lX]", name_max, entry.export_name.c_str(), entry.app_id);
+                    std::snprintf(name, sizeof(name), "%s [%016lX]", display_name.c_str(), entry.app_id);
                 }
             } else {
                 std::snprintf(name, sizeof(name), "[%016lX]", entry.app_id);


### PR DESCRIPTION
Fix issue #347 

Since commit `db06528` ("handle localized game titles in export filenames"), a large number of games show up over MTP and FTP as a bare `[0100XXXXXXXXXXXX]` with no title, and their exported NSP/NCA/XCI filenames lose the title too.

The root cause is that `GetEnglishTitleName()` indexes the NACP language array with `SetLanguage` enum values, which is the wrong index space.

Two follow-on issues made the failure total instead of graceful: there was no fallback when the English name could not be resolved, and the browse listing was made to reuse the export filename, so a filesystem safety option started dictating how titles are displayed.

## NACP language entries are not indexed by `SetLanguage`

`NacpStruct::lang[]` uses the NACP language ordering, not the `SetLanguage` ordering.
libnx keeps an explicit translation table for this in `nx/source/runtime/nacp.c`:

```c
static u32 g_nacpLanguageTable[18] = {
    [SetLanguage_JA]   = 2,
    [SetLanguage_ENUS] = 0,
    [SetLanguage_ENGB] = 1,
    ...
    [SetLanguage_KO]   = 12,
};
```

The old code indexed the array directly with the enum:

```cpp
for (const auto language : {SetLanguage_ENUS, SetLanguage_ENGB}) {
    const auto& entry = nacp.lang[language];
```

`SetLanguage_ENUS` is `1` and `SetLanguage_ENGB` is `12`, so it actually read:

| Intended       | Index read | Language actually read |
| -------------- | ---------- | ---------------------- |
| AmericanEnglish | `lang[1]`  | BritishEnglish         |
| BritishEnglish  | `lang[12]` | Korean                 |

AmericanEnglish, slot `0`, was never checked.
That is the slot populated by most Nintendo of America releases (Dragon Quest for example), so those titles resolved to an **empty English name**.
Where a Korean entry happened to exist, the function returned Korean text, which the ASCII sanitiser then reduced to underscores.

Slot `0` is also where `NormalizeNacpLangData()` stores its fallback entry when it decompresses the newer NACP title format, so titles using that format were affected as well.

`sphaira/source/title_info.cpp`, `GetEnglishTitleName()` now uses the NACP ordering, AmericanEnglish first:

```cpp
enum NacpLanguage {
    NacpLanguage_AmericanEnglish = 0,
    NacpLanguage_BritishEnglish = 1,
};

for (const auto language : {NacpLanguage_AmericanEnglish, NacpLanguage_BritishEnglish}) {
```

## No fallback when the English name is unavailable

`MakeExportTitleName()` used the English name and nothing else when "Fix export filenames" was on, which is the default:

An empty result means the caller emits a title ID only.

`MakeExportTitleName()` now degrades instead of giving up. The sanitising step is factored into a lambda and applied:

1. English name, ASCII only.
2. Displayed (localised) name, ASCII only.
3. Title ID, only if neither candidate has any ASCII safe character left.

With the option off, behaviour is unchanged: the displayed name with Unicode preserved.

This keeps the documented promise of the option, that filenames stay ASCII safe, while no longer throwing away a usable name.

## Browse listing reused the export filename

commit `db06528` made the MTP/FTP folder name and the exported NSP filename the same string.

**Those serve different purposes.**

The folder name is a browse convenience, the filename is what lands on the host filesystem.

Tying the folder name to the ASCII sanitiser meant any title with non ASCII characters, CJK text, a leading decorative character, or just a trademark or accented character, was displayed mangled into underscores or dropped to a bare title ID.

## UTF-8 truncation

The old code truncated with a byte precision specifier:

```cpp
std::snprintf(name, sizeof(name), "%.*s [%016lX]", name_max, entry.export_name.c_str(), entry.app_id);
```

That can cut a UTF-8 sequence in half. It was harmless while every name was forced to ASCII, but now that real titles reach the listing, a trailing partial sequence can make MTP clients bug or drop the entry.

A `TruncateUtf8()` helper was added to the anonymous namespace in `devoptab_game.cpp`.

It walks back off any continuation bytes so the name is always cut on a character boundary.