### PR TITLE
fix: option to view application content in game menu

### DIFF
--- a/sphaira/source/ui/menus/game_menu.cpp
+++ b/sphaira/source/ui/menus/game_menu.cpp
@@ -611,6 +611,10 @@ Menu::Menu(u32 flags) : grid::Menu{"Games"_i18n, flags} {
             }
 
             if (m_entries.size()) {
+                options->Add<SidebarEntryCallback>("View application content"_i18n, [this](){
+                    App::Push<meta::Menu>(m_entries[m_index]);
+                });
+
                 options->Add<SidebarEntryCallback>("Launch random game"_i18n, [this](){
                     const auto random_index = randomGet64() % std::size(m_entries);
                     auto& e = m_entries[random_index];


### PR DESCRIPTION
Resolve #356

Commit `a78e92e` "Add application content shortcut to game menu" moved the entry instead of adding one:

- removed `options->Add<SidebarEntryCallback>("View application content")` from the X → _Game Options sidebar_
- added a `Button::Y` → `"View Content"` action instead (_sphaira/source/ui/menus/game_menu.cpp:522_)

`MainMenu` binds `Button::Y` to its own global "Menu" sidebar (_main_menu.cpp:552_), and then force-pushes its actions down into whichever tab is showing.

Default config is Homebrew / FileBrowser / Appstore (_app.hpp:317-319_), so with stock settings you still reach it via Y button, but if you've put Games on a tab, there's no path to `meta::Menu` at all.