### PR TITLE
Fix MTP/FTP install freeze when installing many files in a row

### DIFF
--- a/sphaira/include/ftpsrv_helper.hpp
+++ b/sphaira/include/ftpsrv_helper.hpp
@@ -13,6 +13,13 @@ using OnInstallWrite = std::function<bool(const void* buf, size_t size)>;
 using OnInstallClose = std::function<void()>;
 
 void InitInstallMode(const OnInstallStart& on_start, const OnInstallWrite& on_write, const OnInstallClose& on_close);
+
+// false once install mode has been (or is being) torn down. polled by the
+// install callbacks so that they never block indefinitely.
+bool IsInstallModeEnabled();
+
+// stops accepting installs and waits for every in-flight install callback to
+// return. never call this whilst holding a lock that a callback may need.
 void DisableInstallMode();
 
 unsigned GetPort();

--- a/sphaira/include/haze_helper.hpp
+++ b/sphaira/include/haze_helper.hpp
@@ -13,6 +13,13 @@ using OnInstallWrite = std::function<bool(const void* buf, size_t size)>;
 using OnInstallClose = std::function<void()>;
 
 void InitInstallMode(const OnInstallStart& on_start, const OnInstallWrite& on_write, const OnInstallClose& on_close);
+
+// false once install mode has been (or is being) torn down. polled by the
+// install callbacks so that they never block indefinitely.
+bool IsInstallModeEnabled();
+
+// stops accepting installs and waits for every in-flight install callback to
+// return. never call this whilst holding a lock that a callback may need.
 void DisableInstallMode();
 
 } // namespace sphaira::libhaze

--- a/sphaira/include/ui/menus/ftp_menu.hpp
+++ b/sphaira/include/ui/menus/ftp_menu.hpp
@@ -13,6 +13,7 @@ struct Menu final : stream::Menu {
     void Update(Controller* controller, TouchInfo* touch) override;
     void Draw(NVGcontext* vg, Theme* theme) override;
     void OnDisableInstallMode() override;
+    bool IsInstallModeActive() const override;
 
 private:
     const char* m_user{};

--- a/sphaira/include/ui/menus/install_stream_menu_base.hpp
+++ b/sphaira/include/ui/menus/install_stream_menu_base.hpp
@@ -3,6 +3,10 @@
 #include "ui/menus/menu_base.hpp"
 #include "yati/source/stream.hpp"
 
+#include <atomic>
+#include <memory>
+#include <vector>
+
 namespace sphaira::ui::menu::stream {
 
 enum class State {
@@ -25,10 +29,26 @@ using OnInstallClose = std::function<void()>;
 struct Stream final : yati::source::Stream {
     Stream(const fs::FsPath& path, std::stop_token token);
 
+    // called by the installer thread.
     Result ReadChunk(void* buf, s64 size, u64* bytes_read) override;
+
+    // called by the transport thread, blocks whilst the buffer is full.
     bool Push(const void* buf, s64 size);
+
+    // no more data will be pushed, the installer drains what is left.
     void Disable();
+
+    // the installer is no longer reading from this stream, this makes any
+    // pending (and future) Push() return immediately rather than block.
+    void SetInstallFinished();
+
     auto& GetPath() const { return m_path; }
+
+private:
+    // waits on cv until signalled or the (short) timeout expires.
+    // m_mutex must be held, no result is returned as a timeout is not an error,
+    // the caller re-checks its condition on every iteration.
+    void Wait(CondVar* cv);
 
 private:
     fs::FsPath m_path{};
@@ -36,10 +56,9 @@ private:
     std::vector<u8> m_buffer{};
     CondVar m_can_read{};
     CondVar m_can_write{};
-
-public:
     Mutex m_mutex{};
     std::atomic_bool m_active{};
+    std::atomic_bool m_install_done{};
 };
 
 struct Menu : MenuBase {
@@ -48,17 +67,40 @@ struct Menu : MenuBase {
 
     virtual void Update(Controller* controller, TouchInfo* touch);
     virtual void Draw(NVGcontext* vg, Theme* theme);
+
+    // tells the transport to stop accepting new installs.
     virtual void OnDisableInstallMode() = 0;
+    // returns false once the transport is no longer accepting installs, used
+    // to break out of the blocking callbacks below.
+    virtual bool IsInstallModeActive() const = 0;
 
 protected:
+    // the below are called from the transport (mtp / ftp) thread and may block
+    // for a long time, they must never be called whilst the transport holds a
+    // lock that the ui thread can also take.
     bool OnInstallStart(const char* path);
     bool OnInstallWrite(const void* buf, size_t size);
     void OnInstallClose();
 
+    // unblocks every in-flight transport callback and disables install mode.
+    // derived classes MUST call this as the first thing in their destructor,
+    // before tearing the transport down, otherwise the transport thread may
+    // still be sat inside one of the callbacks above.
+    void CancelInstallMode();
+
+    // true when the menu is going away or the transport stopped accepting data.
+    bool IsCancelled() const;
+
 private:
-    std::unique_ptr<Stream> m_source{};
-    Thread m_thread{};
-    Mutex m_mutex{};
+    // blocks until the current transfer (and its ui teardown) has completed.
+    // returns false if it was cancelled instead.
+    bool WaitForIdle(u64 poll_ns);
+
+private:
+    // shared_ptr as the installer thread keeps the stream alive for the
+    // duration of the install, regardless of what the transport does next.
+    std::shared_ptr<Stream> m_source{};
+    mutable Mutex m_mutex{};
     State m_state{State::None};
 };
 

--- a/sphaira/include/ui/menus/mtp_menu.hpp
+++ b/sphaira/include/ui/menus/mtp_menu.hpp
@@ -11,6 +11,7 @@ struct Menu final : stream::Menu {
     auto GetShortTitle() const -> const char* override { return "MTP"; };
     void Update(Controller* controller, TouchInfo* touch) override;
     void OnDisableInstallMode() override;
+    bool IsInstallModeActive() const override;
 
 private:
     bool m_was_mtp_enabled{};

--- a/sphaira/source/ftpsrv_helper.cpp
+++ b/sphaira/source/ftpsrv_helper.cpp
@@ -7,6 +7,7 @@
 #include "utils/thread.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <ftpsrv.h>
 #include <ftpsrv_vfs.h>
 #include <nx/vfs_nx.h>
@@ -19,6 +20,7 @@ namespace {
 
 struct InstallSharedData {
     Mutex mutex;
+    CondVar cv;
     std::deque<std::string> queued_files;
 
     void* user;
@@ -27,7 +29,10 @@ struct InstallSharedData {
     OnInstallClose on_close;
 
     bool in_progress;
-    bool enabled;
+    // number of install callbacks currently executing. the callbacks block for
+    // as long as an install takes, so they are *never* run whilst holding
+    // mutex, this counter is what keeps them alive instead.
+    u32 in_flight;
 };
 
 FtpSrvConfig g_ftpsrv_config{};
@@ -61,8 +66,48 @@ void ftp_nro_change_callback(const char* path) {
 
 InstallSharedData g_shared_data{};
 
+// kept as an atomic (rather than a field of the struct above) so that it can be
+// polled by an in-flight callback without taking any lock.
+std::atomic_bool g_install_enabled{false};
+
 const char* SUPPORTED_EXT[] = {
     ".nsp", ".xci", ".nsz", ".xcz", ".msp",
+};
+
+// holds a reference to the install callbacks whilst one of them is running.
+// DisableInstallMode() waits for every reference to be dropped before clearing
+// the callbacks, so they stay valid for as long as the guard is alive, and the
+// shared mutex stays free the whole time the (blocking) callback runs.
+struct InstallCallbackGuard {
+    InstallCallbackGuard() {
+        SCOPED_MUTEX(&g_shared_data.mutex);
+        if (!g_install_enabled) {
+            return;
+        }
+
+        m_data = std::addressof(g_shared_data);
+        m_data->in_flight++;
+    }
+
+    ~InstallCallbackGuard() {
+        if (!m_data) {
+            return;
+        }
+
+        SCOPED_MUTEX(&m_data->mutex);
+        m_data->in_flight--;
+        condvarWakeAll(std::addressof(m_data->cv));
+    }
+
+    InstallCallbackGuard(const InstallCallbackGuard&) = delete;
+    void operator=(const InstallCallbackGuard&) = delete;
+
+    explicit operator bool() const {
+        return m_data != nullptr;
+    }
+
+private:
+    InstallSharedData* m_data{};
 };
 
 struct VfsUserData {
@@ -73,20 +118,37 @@ struct VfsUserData {
 // ive given up with good names.
 void on_thing() {
     log_write("[FTP] doing on_thing\n");
-    SCOPED_MUTEX(&g_shared_data.mutex);
-    log_write("[FTP] locked on_thing\n");
 
-    if (!g_shared_data.in_progress) {
-        if (!g_shared_data.queued_files.empty()) {
-            log_write("[FTP] pushing new file data\n");
-            if (!g_shared_data.on_start || !g_shared_data.on_start(g_shared_data.queued_files[0].c_str())) {
-                g_shared_data.queued_files.clear();
-            } else {
-                log_write("[FTP] success on new file push\n");
-                g_shared_data.in_progress = true;
-            }
-        }
+    InstallCallbackGuard guard;
+    if (!guard) {
+        return;
     }
+
+    OnInstallStart on_start;
+    std::string path;
+    {
+        SCOPED_MUTEX(&g_shared_data.mutex);
+        if (g_shared_data.in_progress || g_shared_data.queued_files.empty()) {
+            return;
+        }
+
+        on_start = g_shared_data.on_start;
+        path = g_shared_data.queued_files[0];
+    }
+
+    log_write("[FTP] pushing new file data\n");
+
+    // called without the lock held, on_start blocks until the previous install
+    // has finished, which can take minutes.
+    if (!on_start || !on_start(path.c_str())) {
+        SCOPED_MUTEX(&g_shared_data.mutex);
+        g_shared_data.queued_files.clear();
+        return;
+    }
+
+    log_write("[FTP] success on new file push\n");
+    SCOPED_MUTEX(&g_shared_data.mutex);
+    g_shared_data.in_progress = true;
 }
 
 int vfs_install_open(void* user, const char* path, enum FtpVfsOpenMode mode) {
@@ -100,7 +162,7 @@ int vfs_install_open(void* user, const char* path, enum FtpVfsOpenMode mode) {
             return -1;
         }
 
-        if (!g_shared_data.enabled) {
+        if (!g_install_enabled) {
             errno = EACCES;
             return -1;
         }
@@ -147,19 +209,27 @@ int vfs_install_read(void* user, void* buf, size_t size) {
 }
 
 int vfs_install_write(void* user, const void* buf, size_t size) {
-    SCOPED_MUTEX(&g_shared_data.mutex);
-    if (!g_shared_data.enabled) {
+    InstallCallbackGuard guard;
+    if (!guard) {
         errno = EACCES;
         return -1;
     }
 
-    auto data = static_cast<VfsUserData*>(user);
-    if (!data->valid) {
-        errno = EACCES;
-        return -1;
+    OnInstallWrite on_write;
+    {
+        SCOPED_MUTEX(&g_shared_data.mutex);
+        auto data = static_cast<VfsUserData*>(user);
+        if (!data->valid) {
+            errno = EACCES;
+            return -1;
+        }
+
+        on_write = g_shared_data.on_write;
     }
 
-    if (!g_shared_data.on_write || !g_shared_data.on_write(buf, size)) {
+    // called without the lock held, on_write blocks whilst the installer
+    // catches up with the data already sent to it.
+    if (!on_write || !on_write(buf, size)) {
         errno = EIO;
         return -1;
     }
@@ -188,27 +258,49 @@ int vfs_install_isfile_ready(void* user) {
 int vfs_install_close(void* user) {
     {
         log_write("[FTP] closing file\n");
-        SCOPED_MUTEX(&g_shared_data.mutex);
         auto data = static_cast<VfsUserData*>(user);
         if (data->valid) {
             log_write("[FTP] closing valid file\n");
 
-            auto it = std::find(g_shared_data.queued_files.cbegin(), g_shared_data.queued_files.cend(), data->path);
-            if (it != g_shared_data.queued_files.cend()) {
-                if (it == g_shared_data.queued_files.cbegin()) {
-                    log_write("[FTP] closing current file\n");
-                    if (g_shared_data.on_close) {
-                        g_shared_data.on_close();
+            OnInstallClose on_close;
+            bool queued = false;
+            {
+                SCOPED_MUTEX(&g_shared_data.mutex);
+                const auto it = std::find(g_shared_data.queued_files.cbegin(), g_shared_data.queued_files.cend(), data->path);
+                queued = it != g_shared_data.queued_files.cend();
+
+                if (queued && it == g_shared_data.queued_files.cbegin()) {
+                    on_close = g_shared_data.on_close;
+                } else if (queued) {
+                    log_write("[FTP] closing other file...\n");
+                } else {
+                    log_write("[FTP] could not find file in queue...\n");
+                }
+            }
+
+            if (on_close) {
+                log_write("[FTP] closing current file\n");
+
+                InstallCallbackGuard guard;
+                if (guard) {
+                    // called without the lock held, on_close blocks until the
+                    // install of this file has finished.
+                    on_close();
+                }
+            }
+
+            // done after on_close so that the queue keeps gating the other
+            // sessions whilst this file is still being installed.
+            if (queued) {
+                SCOPED_MUTEX(&g_shared_data.mutex);
+                const auto it = std::find(g_shared_data.queued_files.cbegin(), g_shared_data.queued_files.cend(), data->path);
+                if (it != g_shared_data.queued_files.cend()) {
+                    if (it == g_shared_data.queued_files.cbegin()) {
+                        g_shared_data.in_progress = false;
                     }
 
-                    g_shared_data.in_progress = false;
-                } else {
-                    log_write("[FTP] closing other file...\n");
+                    g_shared_data.queued_files.erase(it);
                 }
-
-                g_shared_data.queued_files.erase(it);
-            } else {
-                log_write("[FTP] could not find file in queue...\n");
             }
 
             if (data->path) {
@@ -621,6 +713,11 @@ bool Init() {
 }
 
 void Exit() {
+    // done before taking g_mutex, and before joining the ftp thread, as that
+    // thread may still be sat inside a blocking install callback.
+    // DisableInstallMode() is what releases it.
+    DisableInstallMode();
+
     SCOPED_MUTEX(&g_mutex);
     if (!g_is_running) {
         return;
@@ -646,15 +743,35 @@ void ExitSignal() {
 
 void InitInstallMode(const OnInstallStart& on_start, const OnInstallWrite& on_write, const OnInstallClose& on_close) {
     SCOPED_MUTEX(&g_shared_data.mutex);
+    condvarInit(std::addressof(g_shared_data.cv));
     g_shared_data.on_start = on_start;
     g_shared_data.on_write = on_write;
     g_shared_data.on_close = on_close;
-    g_shared_data.enabled = true;
+    g_shared_data.in_progress = false;
+    g_shared_data.queued_files.clear();
+    g_install_enabled = true;
+}
+
+bool IsInstallModeEnabled() {
+    return g_install_enabled;
 }
 
 void DisableInstallMode() {
+    // published first so that any callback which is currently blocked can see
+    // it and return, otherwise the wait below would never finish.
+    g_install_enabled = false;
+
     SCOPED_MUTEX(&g_shared_data.mutex);
-    g_shared_data.enabled = false;
+    while (g_shared_data.in_flight) {
+        condvarWaitTimeout(std::addressof(g_shared_data.cv), std::addressof(g_shared_data.mutex), 1e+8);
+    }
+
+    // safe to drop the callbacks now, nothing can be using them.
+    g_shared_data.on_start = {};
+    g_shared_data.on_write = {};
+    g_shared_data.on_close = {};
+    g_shared_data.in_progress = false;
+    g_shared_data.queued_files.clear();
 }
 
 unsigned GetPort() {

--- a/sphaira/source/haze_helper.cpp
+++ b/sphaira/source/haze_helper.cpp
@@ -7,6 +7,7 @@
 #include "i18n.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <haze.h>
 #include <limits>
 #include <map>
@@ -16,6 +17,7 @@ namespace {
 
 struct InstallSharedData {
     Mutex mutex;
+    CondVar cv;
     std::string current_file;
 
     void* user;
@@ -24,7 +26,10 @@ struct InstallSharedData {
     OnInstallClose on_close;
 
     bool in_progress;
-    bool enabled;
+    // number of install callbacks currently executing. the callbacks block for
+    // as long as an install takes, so they are *never* run whilst holding
+    // mutex, this counter is what keeps them alive instead.
+    u32 in_flight;
 };
 
 constexpr int THREAD_PRIO = 0x20;
@@ -33,24 +38,78 @@ std::atomic_bool g_should_exit = false;
 bool g_is_running{false};
 Mutex g_mutex{};
 
+// kept as an atomic (rather than a field of the struct above) so that it can be
+// polled by an in-flight callback without taking any lock.
+std::atomic_bool g_install_enabled{false};
+
 InstallSharedData g_shared_data{};
 
 const char* SUPPORTED_EXT[] = {
     ".nsp", ".xci", ".nsz", ".xcz", ".msp",
 };
 
+// holds a reference to the install callbacks whilst one of them is running.
+// DisableInstallMode() waits for every reference to be dropped before clearing
+// the callbacks, so they stay valid for as long as the guard is alive, and the
+// shared mutex stays free the whole time the (blocking) callback runs.
+struct InstallCallbackGuard {
+    InstallCallbackGuard() {
+        SCOPED_MUTEX(&g_shared_data.mutex);
+        if (!g_install_enabled) {
+            return;
+        }
+
+        m_data = std::addressof(g_shared_data);
+        m_data->in_flight++;
+    }
+
+    ~InstallCallbackGuard() {
+        if (!m_data) {
+            return;
+        }
+
+        SCOPED_MUTEX(&m_data->mutex);
+        m_data->in_flight--;
+        condvarWakeAll(std::addressof(m_data->cv));
+    }
+
+    InstallCallbackGuard(const InstallCallbackGuard&) = delete;
+    void operator=(const InstallCallbackGuard&) = delete;
+
+    explicit operator bool() const {
+        return m_data != nullptr;
+    }
+
+private:
+    InstallSharedData* m_data{};
+};
+
 bool StartInstall(std::string path) {
-    SCOPED_MUTEX(&g_shared_data.mutex);
-    if (!g_shared_data.enabled || g_shared_data.in_progress || !g_shared_data.current_file.empty() || !g_shared_data.on_start) {
+    InstallCallbackGuard guard;
+    if (!guard) {
         return false;
     }
 
-    g_shared_data.current_file = std::move(path);
-    if (!g_shared_data.on_start(g_shared_data.current_file.c_str())) {
+    OnInstallStart on_start;
+    {
+        SCOPED_MUTEX(&g_shared_data.mutex);
+        if (g_shared_data.in_progress || !g_shared_data.current_file.empty() || !g_shared_data.on_start) {
+            return false;
+        }
+
+        g_shared_data.current_file = path;
+        on_start = g_shared_data.on_start;
+    }
+
+    // called without the lock held, on_start blocks until the previous install
+    // has finished, which can take minutes.
+    if (!on_start(path.c_str())) {
+        SCOPED_MUTEX(&g_shared_data.mutex);
         g_shared_data.current_file.clear();
         return false;
     }
 
+    SCOPED_MUTEX(&g_shared_data.mutex);
     g_shared_data.in_progress = true;
     return true;
 }
@@ -763,8 +822,7 @@ struct FsInstallProxy final : FsProxyVfs {
     using FsProxyVfs::FsProxyVfs;
 
     Result FailedIfNotEnabled() {
-        SCOPED_MUTEX(&g_shared_data.mutex);
-        if (!g_shared_data.enabled) {
+        if (!g_install_enabled) {
             App::Notify("Please launch MTP install menu before trying to install"_i18n);
             R_THROW(FsError_NotImplemented);
         }
@@ -844,14 +902,27 @@ struct FsInstallProxy final : FsProxyVfs {
         auto f = static_cast<File*>(file->impl);
         R_UNLESS(f && f->entry, FsError_PathNotFound);
 
-        SCOPED_MUTEX(&g_shared_data.mutex);
-        if (!g_shared_data.enabled) {
-            log_write("[MTP] failing as not enabled\n");
-            R_THROW(FsError_NotImplemented);
-        }
+        if (f->installing) {
+            InstallCallbackGuard guard;
+            if (!guard) {
+                log_write("[MTP] failing as not enabled\n");
+                R_THROW(FsError_NotImplemented);
+            }
 
-        if (f->installing && (!g_shared_data.on_write || !g_shared_data.on_write(buf, write_size))) {
-            log_write("[MTP] failing as not written\n");
+            OnInstallWrite on_write;
+            {
+                SCOPED_MUTEX(&g_shared_data.mutex);
+                on_write = g_shared_data.on_write;
+            }
+
+            // called without the lock held, on_write blocks whilst the
+            // installer catches up with the data already sent to it.
+            if (!on_write || !on_write(buf, write_size)) {
+                log_write("[MTP] failing as not written\n");
+                R_THROW(FsError_NotImplemented);
+            }
+        } else if (!g_install_enabled) {
+            log_write("[MTP] failing as not enabled\n");
             R_THROW(FsError_NotImplemented);
         }
 
@@ -865,17 +936,28 @@ struct FsInstallProxy final : FsProxyVfs {
             return;
         }
 
-        {
-            SCOPED_MUTEX(&g_shared_data.mutex);
-            if (f->installing) {
-                log_write("[MTP] closing current file\n");
-                if (g_shared_data.on_close) {
-                    g_shared_data.on_close();
+        if (f->installing) {
+            log_write("[MTP] closing current file\n");
+
+            {
+                InstallCallbackGuard guard;
+
+                OnInstallClose on_close;
+                if (guard) {
+                    SCOPED_MUTEX(&g_shared_data.mutex);
+                    on_close = g_shared_data.on_close;
                 }
 
-                g_shared_data.in_progress = false;
-                g_shared_data.current_file.clear();
+                // called without the lock held, on_close blocks until the
+                // install of this file has finished.
+                if (on_close) {
+                    on_close();
+                }
             }
+
+            SCOPED_MUTEX(&g_shared_data.mutex);
+            g_shared_data.in_progress = false;
+            g_shared_data.current_file.clear();
         }
 
         FsProxyVfs::CloseFile(file);
@@ -979,6 +1061,11 @@ bool IsInit() {
 }
 
 void Exit() {
+    // done before taking g_mutex, and before haze::Exit() joins the haze
+    // thread, as that thread may still be sat inside a blocking install
+    // callback. DisableInstallMode() is what releases it.
+    DisableInstallMode();
+
     SCOPED_MUTEX(&g_mutex);
     if (!g_is_running) {
         return;
@@ -995,15 +1082,35 @@ void Exit() {
 
 void InitInstallMode(const OnInstallStart& on_start, const OnInstallWrite& on_write, const OnInstallClose& on_close) {
     SCOPED_MUTEX(&g_shared_data.mutex);
+    condvarInit(std::addressof(g_shared_data.cv));
     g_shared_data.on_start = on_start;
     g_shared_data.on_write = on_write;
     g_shared_data.on_close = on_close;
-    g_shared_data.enabled = true;
+    g_shared_data.in_progress = false;
+    g_shared_data.current_file.clear();
+    g_install_enabled = true;
+}
+
+bool IsInstallModeEnabled() {
+    return g_install_enabled;
 }
 
 void DisableInstallMode() {
+    // published first so that any callback which is currently blocked can see
+    // it and return, otherwise the wait below would never finish.
+    g_install_enabled = false;
+
     SCOPED_MUTEX(&g_shared_data.mutex);
-    g_shared_data.enabled = false;
+    while (g_shared_data.in_flight) {
+        condvarWaitTimeout(std::addressof(g_shared_data.cv), std::addressof(g_shared_data.mutex), 1e+8);
+    }
+
+    // safe to drop the callbacks now, nothing can be using them.
+    g_shared_data.on_start = {};
+    g_shared_data.on_write = {};
+    g_shared_data.on_close = {};
+    g_shared_data.in_progress = false;
+    g_shared_data.current_file.clear();
 }
 
 } // namespace sphaira::libhaze

--- a/sphaira/source/ui/menus/ftp_menu.cpp
+++ b/sphaira/source/ui/menus/ftp_menu.cpp
@@ -30,8 +30,9 @@ Menu::Menu(u32 flags) : stream::Menu{"FTP Install"_i18n, flags} {
 }
 
 Menu::~Menu() {
-    // signal for thread to exit and wait.
-    ftpsrv::DisableInstallMode();
+    // unblocks any ftp callback that is currently waiting on us and then
+    // disables install mode. must happen before the server is torn down.
+    CancelInstallMode();
 
     if (!m_was_ftp_enabled) {
         log_write("[FTP] disabling on exit\n");
@@ -101,6 +102,10 @@ void Menu::Draw(NVGcontext* vg, Theme* theme) {
 
 void Menu::OnDisableInstallMode() {
     ftpsrv::DisableInstallMode();
+}
+
+bool Menu::IsInstallModeActive() const {
+    return ftpsrv::IsInstallModeEnabled();
 }
 
 } // namespace sphaira::ui::menu::ftp

--- a/sphaira/source/ui/menus/install_stream_menu_base.cpp
+++ b/sphaira/source/ui/menus/install_stream_menu_base.cpp
@@ -10,14 +10,13 @@
 namespace sphaira::ui::menu::stream {
 namespace {
 
-enum class InstallState {
-    None,
-    Progress,
-    Finished,
-};
-
 constexpr u64 MAX_BUFFER_SIZE = 1024ULL*1024ULL*1ULL;
-std::atomic<InstallState> INSTALL_STATE{InstallState::None};
+
+// every wait in here is bounded, a missed wakeup then costs a few ms rather
+// than hanging the transport (and with it the whole app) forever.
+constexpr u64 WAIT_TIMEOUT = 1e+8; // 100ms.
+constexpr u64 POLL_INTERVAL_FAST = 1e+6; // 1ms.
+constexpr u64 POLL_INTERVAL_SLOW = 1e+7; // 10ms.
 
 } // namespace
 
@@ -32,29 +31,31 @@ Stream::Stream(const fs::FsPath& path, std::stop_token token) {
     condvarInit(&m_can_write);
 }
 
+void Stream::Wait(CondVar* cv) {
+    // a timeout is expected and not an error, the caller loops and re-checks.
+    condvarWaitTimeout(cv, std::addressof(m_mutex), WAIT_TIMEOUT);
+}
+
 Result Stream::ReadChunk(void* _buf, s64 size, u64* bytes_read) {
     auto buf = static_cast<u8*>(_buf);
     *bytes_read = 0;
 
-    log_write("[Stream::ReadChunk] inside\n");
-    ON_SCOPE_EXIT(
-        log_write("[Stream::ReadChunk] exiting\n");
-    );
-
     while (!m_token.stop_requested()) {
         SCOPED_MUTEX(&m_mutex);
-        if (m_active && m_buffer.empty()) {
-            R_TRY(condvarWait(std::addressof(m_can_read), std::addressof(m_mutex)));
-        }
 
-        if ((!m_active && m_buffer.empty()) || m_token.stop_requested()) {
-            break;
+        if (m_buffer.empty()) {
+            if (!m_active) {
+                break;
+            }
+
+            Wait(std::addressof(m_can_read));
+            continue;
         }
 
         const auto rsize = std::min<s64>(size, m_buffer.size());
         std::memcpy(buf, m_buffer.data(), rsize);
         m_buffer.erase(m_buffer.begin(), m_buffer.begin() + rsize);
-        condvarWakeOne(&m_can_write);
+        condvarWakeAll(std::addressof(m_can_write));
 
         size -= rsize;
         buf += rsize;
@@ -63,6 +64,12 @@ Result Stream::ReadChunk(void* _buf, s64 size, u64* bytes_read) {
         if (!size) {
             R_SUCCEED();
         }
+    }
+
+    // a short read is still a success, yati treats zero bytes read as a
+    // cancelled transfer.
+    if (*bytes_read) {
+        R_SUCCEED();
     }
 
     log_write("[Stream::ReadChunk] failed to read\n");
@@ -75,20 +82,14 @@ bool Stream::Push(const void* _buf, s64 size) {
         return true;
     }
 
-    log_write("[Stream::Push] inside\n");
-    ON_SCOPE_EXIT(
-        log_write("[Stream::Push] exiting\n");
-    );
-
     while (!m_token.stop_requested()) {
-        if (INSTALL_STATE == InstallState::Finished) {
-            log_write("[Stream::Push] install has finished\n");
-            return true;
-        }
-
         SCOPED_MUTEX(&m_mutex);
-        if (m_active && m_buffer.size() >= MAX_BUFFER_SIZE) {
-            R_TRY(condvarWait(std::addressof(m_can_write), std::addressof(m_mutex)));
+
+        // the installer already finished (or gave up) reading this file, the
+        // remaining data is not needed, pretend it was consumed so that the
+        // transport can move on to the next file.
+        if (m_install_done) {
+            return true;
         }
 
         if (!m_active) {
@@ -96,12 +97,17 @@ bool Stream::Push(const void* _buf, s64 size) {
             break;
         }
 
+        if (m_buffer.size() >= MAX_BUFFER_SIZE) {
+            Wait(std::addressof(m_can_write));
+            continue;
+        }
+
         const auto wsize = std::min<s64>(size, MAX_BUFFER_SIZE - m_buffer.size());
         const auto offset = m_buffer.size();
         m_buffer.resize(offset + wsize);
 
         std::memcpy(m_buffer.data() + offset, buf, wsize);
-        condvarWakeOne(&m_can_read);
+        condvarWakeAll(std::addressof(m_can_read));
 
         size -= wsize;
         buf += wsize;
@@ -119,8 +125,15 @@ void Stream::Disable() {
 
     SCOPED_MUTEX(&m_mutex);
     m_active = false;
-    condvarWakeOne(&m_can_read);
-    condvarWakeOne(&m_can_write);
+    condvarWakeAll(std::addressof(m_can_read));
+    condvarWakeAll(std::addressof(m_can_write));
+}
+
+void Stream::SetInstallFinished() {
+    SCOPED_MUTEX(&m_mutex);
+    m_install_done = true;
+    condvarWakeAll(std::addressof(m_can_read));
+    condvarWakeAll(std::addressof(m_can_write));
 }
 
 Menu::Menu(const std::string& title, u32 flags) : MenuBase{title, flags} {
@@ -134,61 +147,143 @@ Menu::Menu(const std::string& title, u32 flags) : MenuBase{title, flags} {
 
     App::SetAutoSleepDisabled(true);
     mutexInit(&m_mutex);
-
-    INSTALL_STATE = InstallState::None;
 }
 
 Menu::~Menu() {
-    // signal for thread to exit and wait.
+    // derived destructors already called CancelInstallMode(), this is only a
+    // safety net in case one of them forgot to.
     m_stop_source.request_stop();
 
-    if (m_source) {
-        m_source->Disable();
+    std::shared_ptr<Stream> source;
+    {
+        SCOPED_MUTEX(&m_mutex);
+        source = m_source;
+    }
+
+    if (source) {
+        source->Disable();
+        source->SetInstallFinished();
     }
 
     App::SetAutoSleepDisabled(false);
 }
 
+bool Menu::IsCancelled() const {
+    // check the cheap, non-virtual condition first, the transport may already
+    // be halfway through tearing us down.
+    if (GetToken().stop_requested()) {
+        return true;
+    }
+
+    return !IsInstallModeActive();
+}
+
+void Menu::CancelInstallMode() {
+    // 1. unblock the transport callbacks that poll this.
+    m_stop_source.request_stop();
+
+    // 2. unblock a transfer that is sat waiting on the installer.
+    //    the stream is taken out of the lock before use, the transport thread
+    //    may be inside Push() with the stream mutex held.
+    std::shared_ptr<Stream> source;
+    {
+        SCOPED_MUTEX(&m_mutex);
+        source = m_source;
+    }
+
+    if (source) {
+        source->Disable();
+        source->SetInstallFinished();
+    }
+
+    // 3. tell the transport to stop accepting installs, this waits for any
+    //    in-flight callback to return, which steps 1 and 2 just guaranteed.
+    OnDisableInstallMode();
+}
+
+bool Menu::WaitForIdle(u64 poll_ns) {
+    for (;;) {
+        {
+            SCOPED_MUTEX(&m_mutex);
+            // Connected means a stream is waiting to be picked up by the ui
+            // thread, Progress means the installer still owns it. In both
+            // cases the previous transfer is not done with yet.
+            if (m_state != State::Connected && m_state != State::Progress) {
+                return true;
+            }
+        }
+
+        if (IsCancelled()) {
+            return false;
+        }
+
+        svcSleepThread(poll_ns);
+    }
+}
+
 void Menu::Update(Controller* controller, TouchInfo* touch) {
     MenuBase::Update(controller, touch);
 
-    SCOPED_MUTEX(&m_mutex);
+    std::shared_ptr<Stream> source;
+    {
+        SCOPED_MUTEX(&m_mutex);
+        if (m_state != State::Connected) {
+            return;
+        }
 
-    if (m_state == State::Connected) {
         m_state = State::Progress;
-        App::Push<ui::ProgressBox>(0, "Installing "_i18n, m_source->GetPath(), [this](auto pbox) -> Result {
-            INSTALL_STATE = InstallState::Progress;
-            const auto rc = yati::InstallFromSource(pbox, m_source.get(), m_source->GetPath());
-            INSTALL_STATE = InstallState::Finished;
+        source = m_source;
+    }
 
-            if (R_FAILED(rc)) {
-                m_source->Disable();
-                R_THROW(rc);
-            }
+    // pushed outside of the lock, creating the progress box spawns a thread
+    // whilst the transport thread is polling m_state.
+    App::Push<ui::ProgressBox>(0, "Installing "_i18n, source->GetPath(), [source](auto pbox) -> Result {
+        // whatever happens, stop the transport from blocking on this stream.
+        ON_SCOPE_EXIT(source->SetInstallFinished());
 
-            R_SUCCEED();
-        }, [this](Result rc){
-            App::PushErrorBox(rc, "Install failed!"_i18n);
+        const auto rc = yati::InstallFromSource(pbox, source.get(), source->GetPath());
+        if (R_FAILED(rc)) {
+            source->Disable();
+            R_THROW(rc);
+        }
 
+        R_SUCCEED();
+    }, [this](Result rc){
+        App::PushErrorBox(rc, "Install failed!"_i18n);
+
+        bool failed;
+        {
             SCOPED_MUTEX(&m_mutex);
 
             if (R_SUCCEEDED(rc)) {
                 App::Notify("Install success!"_i18n);
                 m_state = State::Done;
+                failed = false;
             } else {
                 m_state = State::Failed;
-                OnDisableInstallMode();
+                failed = true;
             }
-        }, ui::ProgressBoxOption::ScreenToggle);
-    }
+        }
+
+        // must be done *without* m_mutex held. the transport thread can be
+        // blocked inside one of our callbacks whilst holding its own lock, and
+        // disabling install mode takes that same lock, which would deadlock.
+        if (failed) {
+            CancelInstallMode();
+        }
+    }, ui::ProgressBoxOption::ScreenToggle);
 }
 
 void Menu::Draw(NVGcontext* vg, Theme* theme) {
     MenuBase::Draw(vg, theme);
 
-    SCOPED_MUTEX(&m_mutex);
+    State state;
+    {
+        SCOPED_MUTEX(&m_mutex);
+        state = m_state;
+    }
 
-    switch (m_state) {
+    switch (state) {
         case State::None:
         case State::Done:
             gfx::drawTextArgs(vg, SCREEN_WIDTH / 2.f, SCREEN_HEIGHT / 2.f, 36.f, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE, theme->GetColour(ThemeEntryID_TEXT_INFO), "Drag'n'Drop (NSP, XCI, NSZ, XCZ, MSP) to the install folder"_i18n.c_str());
@@ -205,51 +300,26 @@ void Menu::Draw(NVGcontext* vg, Theme* theme) {
 }
 
 bool Menu::OnInstallStart(const char* path) {
-    log_write("[Menu::OnInstallStart] inside\n");
+    log_write("[Menu::OnInstallStart] inside: %s\n", path);
 
-    for (;;) {
-        {
-            SCOPED_MUTEX(&m_mutex);
-
-            if (m_state != State::Progress) {
-                break;
-            }
-
-            if (GetToken().stop_requested()) {
-                return false;
-            }
-        }
-
-        svcSleepThread(1e+6);
-    }
-
-    log_write("[Menu::OnInstallStart] got state: %u\n", (u8)m_state);
-
-    if (m_source) {
-        log_write("[Menu::OnInstallStart] we have source\n");
-        for (;;) {
-            {
-                SCOPED_MUTEX(&m_source->m_mutex);
-
-                if (!m_source->m_active && INSTALL_STATE != InstallState::Progress) {
-                    break;
-                }
-
-                if (GetToken().stop_requested()) {
-                    return false;
-                }
-            }
-
-            svcSleepThread(1e+6);
-        }
-
-        log_write("[Menu::OnInstallStart] stopped polling source\n");
+    // wait for the previous transfer to fully complete. the state only leaves
+    // Progress once the progress box has been destroyed, and that joins the
+    // installer thread first, so by this point nothing can still be using the
+    // old stream.
+    if (!WaitForIdle(POLL_INTERVAL_FAST)) {
+        log_write("[Menu::OnInstallStart] cancelled whilst waiting\n");
+        return false;
     }
 
     SCOPED_MUTEX(&m_mutex);
 
-    m_source = std::make_unique<Stream>(path, GetToken());
-    INSTALL_STATE = InstallState::None;
+    // a failed install ends the session, don't accept anything else.
+    if (m_state == State::Failed || GetToken().stop_requested()) {
+        log_write("[Menu::OnInstallStart] rejecting, state: %u\n", (u8)m_state);
+        return false;
+    }
+
+    m_source = std::make_shared<Stream>(path, GetToken());
     m_state = State::Connected;
     log_write("[Menu::OnInstallStart] exiting\n");
 
@@ -257,19 +327,40 @@ bool Menu::OnInstallStart(const char* path) {
 }
 
 bool Menu::OnInstallWrite(const void* buf, size_t size) {
-    log_write("[Menu::OnInstallWrite] inside\n");
-    return m_source->Push(buf, size);
+    std::shared_ptr<Stream> source;
+    {
+        SCOPED_MUTEX(&m_mutex);
+        source = m_source;
+    }
+
+    if (!source) {
+        log_write("[Menu::OnInstallWrite] no source\n");
+        return false;
+    }
+
+    return source->Push(buf, size);
 }
 
 void Menu::OnInstallClose() {
     log_write("[Menu::OnInstallClose] inside\n");
 
-    m_source->Disable();
-
-    // wait until the install has finished before returning.
-    while (INSTALL_STATE == InstallState::Progress) {
-        svcSleepThread(1e+7);
+    std::shared_ptr<Stream> source;
+    {
+        SCOPED_MUTEX(&m_mutex);
+        source = m_source;
     }
+
+    if (source) {
+        // the file has been fully received, let the installer drain whatever
+        // is still buffered.
+        source->Disable();
+    }
+
+    // wait until the install has finished before returning. without this the
+    // transport opens the next file whilst this one is still installing, which
+    // with a queue of many (small) files ends up replacing the stream from
+    // under the installer.
+    WaitForIdle(POLL_INTERVAL_SLOW);
 }
 
 } // namespace sphaira::ui::menu::stream

--- a/sphaira/source/ui/menus/mtp_menu.cpp
+++ b/sphaira/source/ui/menus/mtp_menu.cpp
@@ -24,8 +24,10 @@ Menu::Menu(u32 flags) : stream::Menu{"MTP Install"_i18n, flags} {
 }
 
 Menu::~Menu() {
-    // signal for thread to exit and wait.
-    libhaze::DisableInstallMode();
+    // unblocks any haze callback that is currently waiting on us and then
+    // disables install mode. must happen before libhaze::Exit(), which joins
+    // the haze thread.
+    CancelInstallMode();
 
     if (!m_was_mtp_enabled) {
         log_write("[MTP] disabling on exit\n");
@@ -54,6 +56,10 @@ void Menu::Update(Controller* controller, TouchInfo* touch) {
 
 void Menu::OnDisableInstallMode() {
     libhaze::DisableInstallMode();
+}
+
+bool Menu::IsInstallModeActive() const {
+    return libhaze::IsInstallModeEnabled();
 }
 
 } // namespace sphaira::ui::menu::mtp


### PR DESCRIPTION
Fixes #358 (the freeze half; NTFS support is a separate PR).

## The problem

Dropping a queue of files onto the MTP install folder — typically a folder of DLC, a double
digit number of them — eventually freezes the whole app. It is not specific to DLC: DLC just
happens to produce many small installs back to back, which is what makes the race likely.

There are two separate defects. Both need transfers to follow each other quickly, which is
why a single large NSP never triggers them.

### 1. Lock order inversion

`FsInstallProxy::StartInstall`, `::WriteFile` and `::CloseFile` invoke the install callbacks
while holding `g_shared_data.mutex`:

```cpp
Result WriteFile(haze::File *file, s64 off, const void *buf, u64 write_size) override {
    ...
    SCOPED_MUTEX(&g_shared_data.mutex);
    ...
    if (f->installing && (!g_shared_data.on_write || !g_shared_data.on_write(buf, write_size))) {
```

Those callbacks block for as long as an install takes — `on_write` waits for the installer to
drain the buffer, `on_close` waits for the install to finish, `on_start` waits for the previous
install to finish.

Meanwhile the ui thread takes the two locks in the opposite order. In the progress box done
callback:

```cpp
}, [this](Result rc){
    App::PushErrorBox(rc, "Install failed!"_i18n);

    SCOPED_MUTEX(&m_mutex);          // <- holds m_mutex
    ...
    } else {
        m_state = State::Failed;
        OnDisableInstallMode();      // <- wants g_shared_data.mutex
    }
```

Haze holds `g_shared_data.mutex` and needs `m_mutex` to finish `on_start`; the ui thread holds
`m_mutex` and needs `g_shared_data.mutex`. Deadlock, and the whole app is gone with it since
this is the ui thread.

Two ways in, both easy to hit with a long queue:

- **Any failed install.** The done callback takes that branch.
- **Leaving the menu during a transfer.** `mtp::Menu::~Menu` runs before `stream::Menu::~Menu`,
  so `libhaze::DisableInstallMode()` blocks on the mutex held by a haze thread that is sitting
  in `Stream::Push` — waiting for a stop that only gets requested afterwards, in the base
  destructor that never runs.

### 2. Transfer replaced under the installer

`OnInstallClose()` waits for the install to finish before letting the transport move on:

```cpp
void Menu::OnInstallClose() {
    m_source->Disable();

    // wait until the install has finished before returning.
    while (INSTALL_STATE == InstallState::Progress) {
        svcSleepThread(1e+7);
    }
}
```

`INSTALL_STATE` only becomes `Progress` once the progress box worker thread has started, and
that requires the ui thread to have picked the state up in `Menu::Update` first. A file small
enough to arrive within a single ui frame closes while the state is still `None`, so the loop
falls straight through. `OnInstallStart()` for the next file then finds nothing to wait for and
replaces `m_source` — destroying the stream the installer is about to read from.

## The fix

**Callbacks are never invoked under the transport lock.** An `InstallCallbackGuard` (refcount
plus condvar) keeps them alive instead. `DisableInstallMode()` publishes an atomic first and
then waits for in-flight callbacks to return, so it can no longer block behind one. This
removes the inversion entirely.

**`IsInstallModeEnabled()` / `IsInstallModeActive()`** let every blocking callback bail out as
soon as install mode is torn down, whatever the reason — menu closed, install failed, MTP
turned off, app exit.

**`CancelInstallMode()`** runs at the top of the mtp/ftp menu destructors, before
`libhaze::Exit()` joins the haze thread.

**The handshake no longer goes through the file static `INSTALL_STATE`.** The menu state plus a
per stream flag replaces it, and the waits now cover `State::Connected` as well as
`State::Progress`, which closes the window from defect 2.

**`m_source` is a `shared_ptr`** so the installer thread owns the stream for the whole install
regardless of what the transport does next.

**Every condvar wait has a 100 ms timeout**, so a missed wakeup costs milliseconds rather than
hanging the transport. Belt and braces, but this is the ui thread we are protecting.

`ftpsrv_helper.cpp` has the identical structure — callbacks invoked under
`g_shared_data.mutex`, same `DisableInstallMode` — and gets the same treatment.

## Files touched

```
 sphaira/include/haze_helper.hpp                          |   7 +
 sphaira/include/ftpsrv_helper.hpp                        |   7 +
 sphaira/include/ui/menus/install_stream_menu_base.hpp    |  52 +++-
 sphaira/include/ui/menus/mtp_menu.hpp                    |   1 +
 sphaira/include/ui/menus/ftp_menu.hpp                    |   1 +
 sphaira/source/haze_helper.cpp                           | 155 +++++++++--
 sphaira/source/ftpsrv_helper.cpp                         | 189 ++++++++++---
 sphaira/source/ui/menus/install_stream_menu_base.cpp     | 297 ++++++++++++-------
 sphaira/source/ui/menus/mtp_menu.cpp                     |  10 +-
 sphaira/source/ui/menus/ftp_menu.cpp                     |   9 +-
 10 files changed, 556 insertions(+), 172 deletions(-)
```

## Behaviour

Unchanged apart from the fix. A failed install still ends the session and shows
"Failed to install, press B to exit...", same as before.

One thing worth flagging: while the menu is not the topmost widget — the user opened the
options sidebar, say — the ui thread does not run `Menu::Update`, so a transfer waits until the
sidebar is closed. That was already true before this change (the old `OnInstallStart` polled
`m_state` the same way); it resolves on its own and does not deadlock.

## Testing

Rebased onto current `master` (`eacb54b`) and built there: configure, build and link all pass,
with no warnings coming from sphaira's own code. None of the files touched here have been changed
upstream since 1.0.6, so it applies without conflicts.

**I have not been able to test this on hardware.** The reasoning above is derived from the code
and I am confident in the analysis, but the thing that actually needs confirming is a real run:
30 or so DLC pushed over MTP in one go, plus backing out of the menu mid-transfer. If you or
the reporter can try that before merging, that would be the real check.

## Not in this PR

Two things I found while working on this, kept separate so they can be reviewed on their own —
happy to open either as a follow-up:

- **NTFS support for USB HDD**, the other half of #358.
- **`~Yati()` releases services `Setup()` never acquired.** `splCryptoExit()`, `ns::Exit()` and
  `es::Exit()` run unconditionally, even when `Setup()` failed before acquiring them. The
  refcount guard makes an unbalanced `Exit()` at zero a no-op, so it is harmless on its own, but
  these are refcounted process wide and `game_menu.cpp`, the `game:/` devoptab and `title_info`
  hold them across long lived scopes — an install that fails early closes the session out from
  under them.
