### PR TITLE
NTFS support for USB HDD

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,6 +33,8 @@
                 "ENABLE_NSZ": false,
 
                 "ENABLE_LIBUSBHSFS": false,
+                "ENABLE_NTFS": false,
+                "ENABLE_EXT4": false,
                 "ENABLE_LIBUSBDVD": false,
                 "ENABLE_FTPSRV": false,
                 "ENABLE_LIBHAZE": false,

--- a/README.md
+++ b/README.md
@@ -62,14 +62,34 @@ The USB protocol is the same as tinfoil, so tools such as [ns-usbloader](https:/
 
 Once you have connected your ftp client to your switch, you can upload files to install into the `install` folder.
 
+### Usb HDD (install)
+
+Connected USB mass storage devices show up in the file browser (and as a dump location) under `mounts:/`,
+installing from them works the same as installing from the sd card.
+
+Supported filesystems are FAT12/16/32, exFAT and NTFS. NTFS is provided by
+[NTFS-3G](https://github.com/tuxera/ntfs-3g) and can be turned off at build time with `-DENABLE_NTFS=OFF`.
+EXT2/3/4 is supported as well but off by default, enable it with `-DENABLE_EXT4=ON`.
+
+A few NTFS notes:
+
+- Always eject the drive properly on Windows. If the journal is left dirty, sphaira replays it on mount, but only
+  when `HDD write protect` is off.
+- A drive left behind by Windows fast startup / hibernation is not mounted by default. `Mount hibernated NTFS`
+  in the HDD options forces it, at the cost of the saved Windows session.
+- NTFS is noticeably slower than exFAT. For installing large files, exFAT is the better choice.
+
 ## Building from source
 
 You will first need to install [devkitPro](https://devkitpro.org/wiki/Getting_Started).
 
 Next you will need to install the dependencies:
 ```sh
-sudo pacman -S switch-dev deko3d switch-cmake switch-curl switch-glm switch-zlib switch-mbedtls
+sudo pacman -S switch-dev deko3d switch-cmake switch-curl switch-glm switch-zlib switch-mbedtls switch-ntfs-3g
 ```
+
+`switch-ntfs-3g` is only needed for NTFS support on USB HDDs, configure with `-DENABLE_NTFS=OFF` to build without it.
+For EXT2/3/4 support (`-DENABLE_EXT4=ON`) you also need `switch-lwext4`.
 
 Also you need to have on your environment the packages `git`, `make`, `zip` and `cmake`
 

--- a/assets/romfs/i18n/de.json
+++ b/assets/romfs/i18n/de.json
@@ -410,6 +410,16 @@
     "Angeschlossene Geräte können im FileBrowser verwendet werden und dienen als Backup-Speicherort beim Sichern von Spielen und Spielständen."
   ],
   "HDD write protect": "HDD Schreibschutz",
+  "Show system files": "Systemdateien anzeigen",
+  "hdd_show_system_files_info": [
+    "Nur NTFS. Zeigt Einträge an, die Windows als Systemdateien markiert hat, z. B. $Recycle.Bin. ",
+    "Lass dies deaktiviert, wenn du nicht genau weißt, was du tust."
+  ],
+  "Mount hibernated NTFS": "Ruhezustand-NTFS einbinden",
+  "hdd_ignore_hibernation_info": [
+    "Nur NTFS. Bindet ein Laufwerk ein, das Windows im Ruhezustand hinterlassen hat (Schnellstart). ",
+    "ACHTUNG: Die gespeicherte Windows-Sitzung auf diesem Laufwerk geht dabei verloren."
+  ],
   "Makes the connected HDD read-only.": "Macht den verbundenen HDD schreibgeschützt.",
   "Installing is disabled, enable now?": "Die Installation ist deaktiviert. Jetzt aktivieren?",
   "WARNING: Installing apps will lead to a ban!": "ACHTUNG: Die Installation von Apps führt zu einem Verbot!",

--- a/assets/romfs/i18n/en.json
+++ b/assets/romfs/i18n/en.json
@@ -410,6 +410,16 @@
     "Connected devices can be used in the FileBrowser, as well as a backup location when dumping games and saves."
   ],
   "HDD write protect": "HDD write protect",
+  "Show system files": "Show system files",
+  "hdd_show_system_files_info": [
+    "NTFS only. Shows entries that Windows marked as system files, such as $Recycle.Bin. ",
+    "Leave this off unless you know what you are doing."
+  ],
+  "Mount hibernated NTFS": "Mount hibernated NTFS",
+  "hdd_ignore_hibernation_info": [
+    "NTFS only. Mounts a drive that Windows left in a hibernated state (fast startup). ",
+    "WARNING: the saved Windows session on that drive is lost."
+  ],
   "Makes the connected HDD read-only.": "Makes the connected HDD read-only.",
   "Installing is disabled, enable now?": "Installing is disabled, enable now?",
   "WARNING: Installing apps will lead to a ban!": "WARNING: Installing apps will lead to a ban!",

--- a/sphaira/CMakeLists.txt
+++ b/sphaira/CMakeLists.txt
@@ -6,6 +6,13 @@ option(ENABLE_NSZ "enables exporting to nsz" ON)
 
 # lib options.
 option(ENABLE_LIBUSBHSFS "enables FAT/exFAT hdd mounting" ON)
+# ntfs is provided by ntfs-3g (GPLv2+, compatible with sphaira's GPLv3).
+# needs the portlib: (dkp-)pacman -S switch-ntfs-3g
+option(ENABLE_NTFS "enables NTFS hdd mounting, requires switch-ntfs-3g" ON)
+# ext is provided by lwext4 (GPLv2). off by default, it adds a lot to the final
+# binary size and next to no usb hdd is formatted with it.
+# needs the portlib: (dkp-)pacman -S switch-lwext4
+option(ENABLE_EXT4 "enables EXT2/3/4 hdd mounting, requires switch-lwext4" OFF)
 option(ENABLE_LIBUSBDVD "enables cd/dvd/iso/cue mounting" ON)
 option(ENABLE_FTPSRV "enables MTP server support" ON)
 option(ENABLE_LIBHAZE "enables MTP server support" ON)
@@ -291,9 +298,27 @@ if (ENABLE_NSZ)
 endif()
 
 if (ENABLE_LIBUSBHSFS)
-    # enable this if you want ntfs and ext4 support, at the cost of a huge final binary size.
+    # USBHSFS_GPL turns on both ntfs *and* ext4, they can also be enabled
+    # individually, which is what we do here as ext4 is what costs the most
+    # binary size.
     set(USBHSFS_GPL OFF)
+    set(USBHSFS_NTFS ${ENABLE_NTFS})
+    set(USBHSFS_EXT4 ${ENABLE_EXT4})
     set(USBHSFS_SXOS_DISABLE ON)
+
+    if (ENABLE_NTFS)
+        find_library(ntfs_3g_lib ntfs-3g)
+        if (NOT ntfs_3g_lib)
+            message(FATAL_ERROR "NTFS support is enabled but ntfs-3g is not installed, run '(dkp-)pacman -S switch-ntfs-3g' or configure with -DENABLE_NTFS=OFF")
+        endif()
+    endif()
+
+    if (ENABLE_EXT4)
+        find_library(lwext4_lib lwext4)
+        if (NOT lwext4_lib)
+            message(FATAL_ERROR "EXT4 support is enabled but lwext4 is not installed, run '(dkp-)pacman -S switch-lwext4' or configure with -DENABLE_EXT4=OFF")
+        endif()
+    endif()
 
     FetchContent_Declare(libusbhsfs
         GIT_REPOSITORY https://github.com/ITotalJustice/libusbhsfs.git
@@ -304,6 +329,14 @@ if (ENABLE_LIBUSBHSFS)
 
     target_compile_definitions(sphaira PRIVATE ENABLE_LIBUSBHSFS)
     target_link_libraries(sphaira PRIVATE libusbhsfs)
+
+    if (ENABLE_NTFS)
+        target_compile_definitions(sphaira PRIVATE ENABLE_NTFS)
+    endif()
+
+    if (ENABLE_EXT4)
+        target_compile_definitions(sphaira PRIVATE ENABLE_EXT4)
+    endif()
 else()
     target_sources(sphaira PRIVATE source/ff16/ffunicode.c)
 endif()

--- a/sphaira/include/app.hpp
+++ b/sphaira/include/app.hpp
@@ -88,6 +88,8 @@ public:
     static auto GetNxlinkEnable() -> bool;
     static auto GetHddEnable() -> bool;
     static auto GetWriteProtect() -> bool;
+    static auto GetHddShowSystemFiles() -> bool;
+    static auto GetHddIgnoreHibernation() -> bool;
     static auto GetLogEnable() -> bool;
     static auto GetReplaceHbmenuEnable() -> bool;
     static auto GetInstallEnable() -> bool;
@@ -107,6 +109,11 @@ public:
     static void SetNxlinkEnable(bool enable);
     static void SetHddEnable(bool enable);
     static void SetWriteProtect(bool enable);
+    static void SetHddShowSystemFiles(bool enable);
+    static void SetHddIgnoreHibernation(bool enable);
+    // re-mounts every connected usb device so that changed mount options
+    // (and the ntfs specific ones in particular) take effect right away.
+    static void RemountHdd();
     static void SetLogEnable(bool enable);
     static void SetReplaceHbmenuEnable(bool enable);
     static void SetInstallSysmmcEnable(bool enable);
@@ -306,6 +313,9 @@ public:
     option::OptionBool m_ftp_enabled{INI_SECTION, "ftp_enabled", false};
     option::OptionBool m_hdd_enabled{INI_SECTION, "hdd_enabled", true};
     option::OptionBool m_hdd_write_protect{INI_SECTION, "hdd_write_protect", false};
+    // ntfs only, see App::GetHddMountFlags().
+    option::OptionBool m_hdd_show_system_files{INI_SECTION, "hdd_show_system_files", false};
+    option::OptionBool m_hdd_ignore_hibernation{INI_SECTION, "hdd_ignore_hibernation", false};
 
     option::OptionBool m_log_enabled{INI_SECTION, "log_enabled", false};
     option::OptionBool m_replace_hbmenu{INI_SECTION, "replace_hbmenu", false};

--- a/sphaira/source/app.cpp
+++ b/sphaira/source/app.cpp
@@ -48,6 +48,49 @@ extern "C" {
 } // extern "C"
 
 namespace sphaira {
+
+#ifdef ENABLE_LIBUSBHSFS
+namespace {
+
+// builds the libusbhsfs mount flags out of the user's hdd options and pushes
+// them to the library. only affects devices mounted *after* this call, use
+// App::RemountHdd() if the change should be visible right away.
+//
+// most of these are NTFS only, they are ignored for FAT/exFAT volumes.
+void ApplyHddMountFlags() {
+    u32 flags = UsbHsFsMountFlags_None;
+
+    if (App::GetWriteProtect()) {
+        flags |= UsbHsFsMountFlags_ReadOnly;
+    } else {
+        // an NTFS volume with a dirty journal (the normal state after the drive
+        // was pulled out of a pc without ejecting it) is refused for writing
+        // unless the journal is replayed first.
+        flags |= UsbHsFsMountFlags_ReplayJournal;
+    }
+
+    // windows marks plenty of ordinary folders as hidden, without this they
+    // would silently not show up in the file browser.
+    flags |= UsbHsFsMountFlags_ShowHiddenFiles;
+
+    // deliberately *not* setting UsbHsFsMountFlags_UpdateAccessTimes (which is
+    // part of the library default), writing back an access time after every
+    // read costs a lot of speed when installing from an NTFS drive.
+
+    if (App::GetHddShowSystemFiles()) {
+        flags |= UsbHsFsMountFlags_ShowSystemFiles;
+    }
+
+    if (App::GetHddIgnoreHibernation()) {
+        flags |= UsbHsFsMountFlags_IgnoreHibernation;
+    }
+
+    usbHsFsSetFileSystemMountFlags(flags);
+}
+
+} // namespace
+#endif // ENABLE_LIBUSBHSFS
+
 namespace {
 
 constexpr const u8 DEFAULT_IMAGE_DATA[]{
@@ -705,6 +748,14 @@ auto App::GetWriteProtect() -> bool {
     return g_app->m_hdd_write_protect.Get();
 }
 
+auto App::GetHddShowSystemFiles() -> bool {
+    return g_app->m_hdd_show_system_files.Get();
+}
+
+auto App::GetHddIgnoreHibernation() -> bool {
+    return g_app->m_hdd_ignore_hibernation.Get();
+}
+
 auto App::GetLogEnable() -> bool {
     return g_app->m_log_enabled.Get();
 }
@@ -781,9 +832,7 @@ void App::SetHddEnable(bool enable) {
         g_app->m_hdd_enabled.Set(enable);
 #ifdef ENABLE_LIBUSBHSFS
         if (enable) {
-            if (App::GetWriteProtect()) {
-                usbHsFsSetFileSystemMountFlags(UsbHsFsMountFlags_ReadOnly);
-            }
+            ApplyHddMountFlags();
             usbHsFsInitialize(1);
         } else {
             usbHsFsExit();
@@ -795,15 +844,35 @@ void App::SetHddEnable(bool enable) {
 void App::SetWriteProtect(bool enable) {
     if (App::GetWriteProtect() != enable) {
         g_app->m_hdd_write_protect.Set(enable);
-
-#ifdef ENABLE_LIBUSBHSFS
-        if (enable) {
-            usbHsFsSetFileSystemMountFlags(UsbHsFsMountFlags_ReadOnly);
-        } else {
-            usbHsFsSetFileSystemMountFlags(0);
-        }
-#endif // ENABLE_LIBUSBHSFS
+        App::RemountHdd();
     }
+}
+
+void App::SetHddShowSystemFiles(bool enable) {
+    if (App::GetHddShowSystemFiles() != enable) {
+        g_app->m_hdd_show_system_files.Set(enable);
+        App::RemountHdd();
+    }
+}
+
+void App::SetHddIgnoreHibernation(bool enable) {
+    if (App::GetHddIgnoreHibernation() != enable) {
+        g_app->m_hdd_ignore_hibernation.Set(enable);
+        App::RemountHdd();
+    }
+}
+
+void App::RemountHdd() {
+#ifdef ENABLE_LIBUSBHSFS
+    ApplyHddMountFlags();
+
+    // mount flags are only read when a device is mounted, so cycle the library
+    // to pick them up, otherwise the user would have to unplug the drive.
+    if (App::GetHddEnable()) {
+        usbHsFsExit();
+        usbHsFsInitialize(1);
+    }
+#endif // ENABLE_LIBUSBHSFS
 }
 
 void App::SetLogEnable(bool enable) {
@@ -1587,6 +1656,8 @@ App::App(const char* argv0) {
             else if (app->m_ftp_enabled.LoadFrom(Key, Value)) {}
             else if (app->m_hdd_enabled.LoadFrom(Key, Value)) {}
             else if (app->m_hdd_write_protect.LoadFrom(Key, Value)) {}
+            else if (app->m_hdd_show_system_files.LoadFrom(Key, Value)) {}
+            else if (app->m_hdd_ignore_hibernation.LoadFrom(Key, Value)) {}
             else if (app->m_log_enabled.LoadFrom(Key, Value)) {}
             else if (app->m_replace_hbmenu.LoadFrom(Key, Value)) {}
             else if (app->m_default_music.LoadFrom(Key, Value)) {}
@@ -1778,10 +1849,7 @@ App::App(const char* argv0) {
 #ifdef ENABLE_LIBUSBHSFS
         if (App::GetHddEnable()) {
             SCOPED_TIMESTAMP("hdd init");
-            if (App::GetWriteProtect()) {
-                usbHsFsSetFileSystemMountFlags(UsbHsFsMountFlags_ReadOnly);
-            }
-
+            ApplyHddMountFlags();
             usbHsFsInitialize(1);
         }
 #endif // ENABLE_LIBUSBHSFS
@@ -2704,6 +2772,24 @@ void App::DisplayHddOptions(bool left_side) {
     options->Add<ui::SidebarEntryBool>("HDD write protect"_i18n, App::GetWriteProtect(), [](bool& enable){
         App::SetWriteProtect(enable);
     },  "Makes the connected HDD read-only."_i18n);
+
+#ifdef ENABLE_NTFS
+    options->Add<ui::SidebarEntryBool>("Show system files"_i18n, App::GetHddShowSystemFiles(), [](bool& enable){
+        App::SetHddShowSystemFiles(enable);
+    },  i18n::get("hdd_show_system_files_info",
+            "NTFS only. Shows entries that Windows marked as system files, such as $Recycle.Bin. "
+            "Leave this off unless you know what you are doing."
+        )
+    );
+
+    options->Add<ui::SidebarEntryBool>("Mount hibernated NTFS"_i18n, App::GetHddIgnoreHibernation(), [](bool& enable){
+        App::SetHddIgnoreHibernation(enable);
+    },  i18n::get("hdd_ignore_hibernation_info",
+            "NTFS only. Mounts a drive that Windows left in a hibernated state (fast startup). "
+            "WARNING: the saved Windows session on that drive is lost."
+        )
+    );
+#endif // ENABLE_NTFS
 }
 
 void App::ShowEnableInstallPrompt() {


### PR DESCRIPTION
Implements the feature request half of #358 (the freeze half is #359).

## What this adds

NTFS on USB mass storage devices, on by default. FAT12/16/32 and exFAT already worked; NTFS is
by far the most common format for a drive that has previously lived on a Windows PC, which is
most of them.

## Why it was not just a build flag

The `ENABLE_LIBUSBHSFS` block already had a note about this:

```cmake
# enable this if you want ntfs and ext4 support, at the cost of a huge final binary size.
set(USBHSFS_GPL OFF)
```

`USBHSFS_GPL` turns on ntfs **and** ext4 together, and ext4 (lwext4) is what costs the most
size. The pinned libusbhsfs revision can enable them individually, so this sets `USBHSFS_NTFS`
and `USBHSFS_EXT4` separately: NTFS on by default, ext4 off behind a new `ENABLE_EXT4`.

Cost measured on a release build: **+167 KiB** (4,447,429 → 4,618,481 bytes).

## The part that actually mattered: mount flags

`usbHsFsSetFileSystemMountFlags()` was being called with either `ReadOnly` or `0`:

```cpp
if (enable) {
    usbHsFsSetFileSystemMountFlags(UsbHsFsMountFlags_ReadOnly);
} else {
    usbHsFsSetFileSystemMountFlags(0);
}
```

For FAT that is harmless, fatfs only looks at `ReadOnly`. For NTFS, `0` disables everything the
library's own default (`UsbHsFsMountFlags_Default`) turns on, and two of those matter a lot:

- **`ReplayJournal`.** ntfs-3g refuses a writable mount when `$LogFile` is dirty, which is the
  normal state of any drive that was unplugged from Windows without ejecting. Without this flag
  the drive simply never appears, with no indication why. Now always set for writable mounts,
  and deliberately not set for read-only ones, where ntfs-3g mounts a dirty volume anyway.
- **`ShowHiddenFiles`.** Windows marks plenty of perfectly ordinary folders as hidden. Without
  this they are silently missing from the file browser. Now always set.

`UpdateAccessTimes` is part of the library default but is deliberately **not** set here: writing
an access time back after every read costs a noticeable amount of speed when installing from an
NTFS drive, and nothing in sphaira reads atime.

There is a side effect worth calling out: `HDD write protect` previously only changed the flags,
which are read at mount time, so toggling it did nothing until the drive was physically
unplugged and reconnected. Flag changes now remount, so it takes effect immediately.

## New options

Two entries in the HDD options, both NTFS only, both off by default:

- **Show system files** — surfaces entries Windows marked as system files, `$Recycle.Bin` and
  friends.
- **Mount hibernated NTFS** — mounts a drive left in a hibernated state by Windows fast startup.
  Carries an explicit warning in the description that the saved Windows session is lost, which
  is why it is opt-in rather than on.

English and German strings added; the other locales fall back to English, as the code passes the
English text as the fallback argument.

## Building

`switch-ntfs-3g` is a member of the `switch-portlibs` group, which the `devkitpro/devkita64`
image already installs, so **CI needs no change**. For a local build the README now lists it in
the pacman line. Configure with `-DENABLE_NTFS=OFF` to build without it; the CMake check fails
early with a message naming the package rather than dying at link time.

`-DENABLE_EXT4=ON` additionally needs `switch-lwext4`.

## Files

```
 CMakePresets.json         |   2 +
 README.md                 |  22 ++++++-
 assets/romfs/i18n/de.json |  10 +++
 assets/romfs/i18n/en.json |  10 +++
 sphaira/CMakeLists.txt    |  35 ++++++++++-
 sphaira/include/app.hpp   |  10 +++
 sphaira/source/app.cpp    | 112 ++++++++++++++++++++++++++++++++------
 7 files changed, 186 insertions(+), 15 deletions(-)
```

## Testing

Built on top of current `master` (`eacb54b`): configure, build and link all pass, the
`ntfs-3g/ntfs_dev.o` and `ntfs_disk_io.o` objects are in the build, and there are no warnings
from sphaira's own code.

**I have not been able to test this on hardware.** What still needs a real check is the part
this PR is actually about: that an NTFS drive mounts, that a dirty one mounts because of
`ReplayJournal`, and that installing from it works. If you or the reporter of #358 can try it
before merging, that would be the real confirmation.

## Relationship to #359

Independent. #359 fixes the MTP install freeze and touches a disjoint set of files; this one
touches the HDD path. Either can go first.
