### PR TITLE
Only release the services Yati::Setup() actually acquired

### DIFF
--- a/sphaira/source/yati/yati.cpp
+++ b/sphaira/source/yati/yati.cpp
@@ -369,6 +369,14 @@ struct Yati {
     std::unique_ptr<container::Base> container{};
     Config config{};
     keys::Keys keys{};
+
+    // tracks what Setup() actually managed to acquire. these services are
+    // refcounted process wide and other parts of sphaira (the game menu, the
+    // game:/ devoptab, ...) hold them at the same time, so releasing one that
+    // we never acquired would close the session out from under them.
+    bool spl_crypto_init{};
+    bool ns_init{};
+    bool es_init{};
 };
 
 auto ThreadData::GetResults() volatile -> Result {
@@ -866,9 +874,21 @@ Yati::Yati(ui::ProgressBox* _pbox, source::Base* _source) : pbox{_pbox}, source{
 }
 
 Yati::~Yati() {
-    splCryptoExit();
-    ns::Exit();
-    es::Exit();
+    // released in reverse order of acquisition, and only what Setup() got as
+    // far as acquiring, see the comment on the flags.
+    // note: the ncm handles below don't need the same treatment, they are
+    // zero initialised and closing an unopened one is a no-op.
+    if (es_init) {
+        es::Exit();
+    }
+
+    if (ns_init) {
+        ns::Exit();
+    }
+
+    if (spl_crypto_init) {
+        splCryptoExit();
+    }
 
     for (size_t i = 0; i < std::size(NCM_STORAGE_IDS); i++) {
         ncmContentMetaDatabaseClose(std::addressof(ncm_db[i]));
@@ -902,9 +922,15 @@ Result Yati::Setup(const ConfigOverride& override) {
     storage_id = config.sd_card_install ? NcmStorageId_SdCard : NcmStorageId_BuiltInUser;
 
     R_TRY(source->GetOpenResult());
+
     R_TRY(splCryptoInitialize());
+    spl_crypto_init = true;
+
     R_TRY(ns::Initialize());
+    ns_init = true;
+
     R_TRY(es::Initialize());
+    es_init = true;
 
     for (size_t i = 0; i < std::size(NCM_STORAGE_IDS); i++) {
         R_TRY(ncmOpenContentMetaDatabase(std::addressof(ncm_db[i]), NCM_STORAGE_IDS[i]));


### PR DESCRIPTION
`~Yati()` releases `splCrypto`, `ns` and `es` unconditionally, even when `Setup()` bailed out
before acquiring them.

```cpp
Yati::~Yati() {
    splCryptoExit();
    ns::Exit();
    es::Exit();
    ...
```

`Setup()` can fail at four points before all three are held:

```cpp
    R_TRY(source->GetOpenResult());     // nothing acquired yet
    R_TRY(splCryptoInitialize());       // nothing acquired yet
    R_TRY(ns::Initialize());            // splCrypto held
    R_TRY(es::Initialize());            // splCrypto + ns held
```

## Why this is not harmless

The obvious objection is that `serviceGuardExit()` already guards against this:

```c
NX_INLINE void serviceGuardExit(ServiceGuard* g, void (*cleanupFunc)(void))
{
    mutexLock(&g->mutex);
    if (g->refCount && (--g->refCount) == 0)
        cleanupFunc();
    mutexUnlock(&g->mutex);
}
```

That is true, and it is why this has not blown up more loudly: an `Exit()` at refcount zero does
nothing and cannot underflow. If `Yati` were the only user of these services, the code would be
fine.

It is not. The refcount is process wide, and several long lived scopes hold the same services:

- **`game::Menu`** takes `ns` and `es` in its constructor and drops them in its destructor, so
  it holds both for as long as the game menu exists.
- **The `game:/` devoptab** takes `es` and `ns` when mounted and holds them until unmounted.
- **`title_info.cpp`** takes `ns` around its work.

So when an install's `Setup()` fails early while the game menu is alive, the destructor
decrements a refcount it never incremented. The count reaches zero, `_nsExCleanup()` runs, and
the session is closed **out from under the game menu**, whose subsequent `ns` calls then run
against a dead handle.

The most reachable path is the very first line: a source that cannot be opened releases all
three without having acquired any of them.

## The fix

Track what was acquired and release only that, in reverse order:

```cpp
    R_TRY(splCryptoInitialize());
    spl_crypto_init = true;

    R_TRY(ns::Initialize());
    ns_init = true;

    R_TRY(es::Initialize());
    es_init = true;
```

The `ncm` handles in the same destructor deliberately keep their unconditional close. They are
zero initialised, and `serviceClose()` on an unopened `Service` hits neither branch
(`own_handle` and `object_id` are both zero) and just clears the struct, so closing one that was
never opened is genuinely a no-op. Only the refcounted service guards needed the treatment.

## Files

```
 sphaira/source/yati/yati.cpp | 32 +++++++++++++++++++++++++++-----
 1 file changed, 29 insertions(+), 3 deletions(-)
```

## Testing

Built on top of current `master` (`eacb54b`): configure, build and link all pass, no warnings
from sphaira's own code.

**Not tested on hardware.** This one is a reasoning-level fix rather than something I could
reproduce on demand — triggering it needs an install whose `Setup()` fails while the game menu
holds the services, and the symptom afterwards is other code failing, not the install. The
change itself is small and strictly narrows what the destructor touches, so the risk of it
making anything worse is low, but a second pair of eyes on the reasoning is worth more than my
say-so here.

## Relationship to #359 and #361

Independent of both. Different file, different subsystem. Found while working on #359.
