### PR TITLE
Update workflow, use custom libgloss and remove unneeded `FixDkpBug()`

### DIFF
--- a/.github/workflows/build_presets.yml
+++ b/.github/workflows/build_presets.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Update packages
+      run: |
+        sudo -n apt-get update
+        sudo -n apt-get upgrade -y texinfo
+
     - name: Silence all git safe directory warnings
       run: git config --system --add safe.directory '*'
 

--- a/.github/workflows/build_presets.yml
+++ b/.github/workflows/build_presets.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - dev
@@ -19,10 +20,34 @@ jobs:
     container: devkitpro/devkita64:latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
+
+    - name: Silence all git safe directory warnings
+      run: git config --system --add safe.directory '*'
+
+    - name: Checkout latest libnx commit
+      run: |
+        git clone --recurse-submodules https://github.com/switchbrew/libnx.git
+
+    - name: Checkout custom iosupport branch newlib commit
+      run: |
+        git clone https://github.com/R-YaTian/newlib.git -b iosupport
 
     # fetch latest cmake
-    - uses: lukka/get-cmake@v3.31.6
+    - uses: lukka/get-cmake@v4.4.2
+
+    - name: Set workspace permissions
+      run: chmod 777 -R "$GITHUB_WORKSPACE"
+
+    - name: Build libgloss
+      run: |
+        cd newlib
+        ./build-libgloss-local.sh
+
+    - name: Build and install libnx
+      run: |
+        cd libnx
+        make install -j$(nproc)
 
     - name: Configure CMake
       run: cmake --preset ${{ matrix.preset }}

--- a/sphaira/include/utils/devoptab.hpp
+++ b/sphaira/include/utils/devoptab.hpp
@@ -34,10 +34,6 @@ Result GetNetworkDevices(location::StdioEntries& out);
 void UmountAllNeworkDevices();
 void UmountNeworkDevice(const fs::FsPath& mount);
 
-// manually set the array so that we can avoid nullptr access.
-// SEE: https://github.com/devkitPro/newlib/issues/35
-void FixDkpBug();
-
 void DisplayDevoptabSideBar();
 
 } // namespace sphaira::devoptab

--- a/sphaira/source/utils/devoptab_common.cpp
+++ b/sphaira/source/utils/devoptab_common.cpp
@@ -11,11 +11,6 @@
 #include <minIni.h>
 #include <curl/curl.h>
 
-// see FixDkpBug();
-extern "C" {
-    extern const devoptab_t dotab_stdnull;
-}
-
 namespace sphaira::devoptab::common {
 namespace {
 
@@ -1596,17 +1591,6 @@ void UmountNeworkDevice(const fs::FsPath& mount) {
         it->reset();
     } else {
         log_write("[DEVOPTAB] No such mount %s\n", mount.s);
-    }
-}
-
-void FixDkpBug() {
-    const int max = 35;
-
-    for (int i = 0; i < max; i++) {
-        if (!devoptab_list[i]) {
-            devoptab_list[i] = &dotab_stdnull;
-            log_write("[DEVOPTAB] Fixing DKP bug at index: %d\n", i);
-        }
     }
 }
 


### PR DESCRIPTION
Build and install the latest commit of `libnx` and the custom `libgloss`.

The custom `libgloss` is primarily intended to address issues with `devoptab` initialization and pointer access.
For example, when managing files on a USB external drive, sphaira will crash if the USB connection becomes unstable or the device is unplugged without the devoptab fix.
See https://github.com/devkitPro/newlib/issues/36 for more information.

Note: PR #369 requires the latest commit of libnx to build correctly without errors.